### PR TITLE
Support pagination for `getJson`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add pagination support for `getJson`.
 - Export error classes.
 - Add examples.
 - [Apple Reviews] Add more sort options.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import { getJson } from "https://deno.land/x/serpapi/mod.ts";
 - Promises and async/await support.
 - Callbacks support.
 - [Examples in JavaScript/TypeScript on Node.js/Deno using ESM/CommonJS, and more](https://github.com/serpapi/serpapi-javascript/tree/master/examples).
-- (Planned) Pagination support.
+- [Pagination support](#pagination).
 - (Planned) More error classes.
 
 ## Configuration
@@ -71,6 +71,33 @@ config.timeout = 60000;
 await getJson("google", { q: "coffee" }); // uses the API key defined in the config
 await getJson("google", { api_key: API_KEY_2, q: "coffee" }); // API_KEY_2 will be used
 ```
+
+## Pagination
+
+Search engines handle pagination in several different ways. Some rely on an
+"offset" value to return results starting from a specific index, while some
+others rely on the typical notion of a "page". These are often combined with a
+"size" value to define how many results are returned in a search.
+
+This module helps you handle pagination easily. After receiving search results
+from `getJson`, simply call the `next()` method on the returned object to
+retrieve the next page of results. If there is no `next()` method, then either
+pagination is not supported for the search engine or there are no more pages to
+be retrieved.
+
+```js
+const page1 = await getJson("google", { q: "coffee", start: 15 });
+const page2 = await page1.next?.();
+```
+
+You may pass in the engine's supported pagination parameters as per normal. In
+the above example, the first page contains the 15th to the 24th result while the
+second page contains the 25th to the 34th result.
+
+Note that if you set `no_cache` to `true`, all subsequent `next()` calls will
+not return cached results.
+
+Refer to the [`getJson` definition below](#getjson) for more examples.
 
 ## Functions
 
@@ -102,6 +129,8 @@ await getJson("google", { api_key: API_KEY_2, q: "coffee" }); // API_KEY_2 will 
 Get a JSON response based on search parameters.
 
 - Accepts an optional callback.
+- Get the next page of results by calling the `.next()` method on the returned
+  response object.
 
 #### Parameters
 
@@ -116,11 +145,48 @@ Get a JSON response based on search parameters.
 #### Examples
 
 ```javascript
-// async/await
+// single call (async/await)
 const json = await getJson("google", { api_key: API_KEY, q: "coffee" });
 
-// callback
+// single call (callback)
 getJson("google", { api_key: API_KEY, q: "coffee" }, console.log);
+```
+
+```javascript
+// pagination (async/await)
+const page1 = await getJson("google", { q: "coffee", start: 15 });
+const page2 = await page1.next?.();
+```
+
+```javascript
+// pagination (callback)
+getJson("google", { q: "coffee", start: 15 }, (page1) => {
+  page1.next?.((page2) => {
+    console.log(page2);
+  });
+});
+```
+
+```javascript
+// pagination loop (async/await)
+const organicResults = [];
+let page = await getJson("google", { api_key: API_KEY, q: "coffee" });
+while (page) {
+  organicResults.push(...page.organic_results);
+  if (organicResults.length >= 30) break;
+  page = await page.next?.();
+}
+```
+
+```javascript
+// pagination loop (callback)
+const organicResults = [];
+getJson("google", { api_key: API_KEY, q: "coffee" }, (page) => {
+  organicResults.push(...page.organic_results);
+  if (organicResults.length < 30 && page.next) {
+    page.next();
+  }
+});
 ```
 
 ### getHtml

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,8 @@ export type BaseResponse<P = Record<string | number | symbol, never>> = {
   search_parameters:
     & { engine: string }
     & Omit<BaseParameters & P, "api_key" | "no_cache" | "async" | "timeout">;
+  serpapi_pagination?: { next: string };
+  pagination?: { next: string };
   // deno-lint-ignore no-explicit-any
   [key: string]: any; // TODO(seb): use recursive type
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,9 @@ export type BaseResponse<P = Record<string | number | symbol, never>> = {
     & Omit<BaseParameters & P, "api_key" | "no_cache" | "async" | "timeout">;
   serpapi_pagination?: { next: string };
   pagination?: { next: string };
+  next?: (
+    callback?: (json: BaseResponse<P>) => void,
+  ) => Promise<BaseResponse<P>>;
   // deno-lint-ignore no-explicit-any
   [key: string]: any; // TODO(seb): use recursive type
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,6 +59,20 @@ export function extractNextParameters<
   }
 }
 
+export function haveParametersChanged(
+  parameters: Record<string, unknown>,
+  nextParameters: Record<string, unknown>,
+) {
+  const keys = [
+    ...Object.keys(parameters),
+    ...Object.keys(nextParameters),
+  ];
+  const uniqueKeys = new Set(keys);
+  return [...uniqueKeys].some((key) =>
+    `${parameters[key]}` !== `${nextParameters[key]}` // string comparison
+  );
+}
+
 function getSource() {
   const moduleSource = `serpapi@${version}`;
   try {

--- a/tests/engines/apple_reviews_test.ts
+++ b/tests/engines/apple_reviews_test.ts
@@ -1,0 +1,202 @@
+// deno-lint-ignore-file no-explicit-any
+import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { spy, Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { _internals } from "../../src/utils.ts";
+import { config, getJson } from "../../mod.ts";
+import {
+  MSG_ASSERT_HAS_LAST_PAGE,
+  MSG_ASSERT_HAS_MULTIPLE_PAGES,
+  MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+} from "./constants.ts";
+
+loadSync({ export: true });
+const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
+const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
+const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
+  ? "http://localhost:3000"
+  : "https://serpapi.com";
+
+describe("apple_reviews", {
+  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+  sanitizeResources: false,
+}, () => {
+  let urlStub: Stub;
+  const engine = "apple_reviews";
+  const productId = "534220544";
+
+  beforeAll(() => {
+    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+  });
+
+  beforeEach(() => {
+    config.api_key = SERPAPI_TEST_KEY;
+  });
+
+  afterEach(() => {
+    config.api_key = null;
+  });
+
+  afterAll(() => {
+    urlStub.restore();
+  });
+
+  it("getJson pagination", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      const ids: number[] = [];
+      let page;
+      page = await getJson(engine, { product_id: productId });
+      while (page) {
+        ids.push(...page.reviews.map((r: any) => r.id));
+        if (ids.length >= 50) break;
+        page = await page.next?.();
+      }
+      assert(new Set(ids).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+    });
+
+    await t.step("callback", async () => {
+      const ids: number[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { product_id: productId }, (page) => {
+          ids.push(...page.reviews.map((r: any) => r.id));
+          if (ids.length < 50 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(ids).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination keeps original parameter keys", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const executeSpy = spy(_internals, "execute");
+    config.api_key = null;
+
+    await t.step("async/await", async () => {
+      const page1 = await getJson(engine, {
+        api_key: SERPAPI_TEST_KEY,
+        no_cache: false,
+        product_id: productId,
+      });
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await page1.next();
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    await t.step("callback", async () => {
+      const page1 = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+        (res) =>
+          getJson(engine, {
+            api_key: SERPAPI_TEST_KEY,
+            no_cache: false,
+            product_id: productId,
+          }, res),
+      );
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await new Promise((res) => page1.next?.(res));
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    executeSpy.restore();
+  });
+
+  it("getJson pagination with page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { product_id: productId });
+    const idsOnFirstPage = firstPage.reviews.map((r: any) => r.id);
+
+    await t.step("async/await", async () => {
+      const ids: number[] = [];
+      let page;
+      page = await getJson(engine, { product_id: productId, page: "2" });
+      while (page) {
+        ids.push(...page.reviews.map((r: any) => r.id));
+        if (ids.length >= 50) break;
+        page = await page.next?.();
+      }
+
+      assert(new Set(ids).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        ids.some((id) => !idsOnFirstPage.includes(id)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const ids: number[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { product_id: productId, page: "2" }, (page) => {
+          ids.push(...page.reviews.map((r: any) => r.id));
+          if (ids.length < 50 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(ids).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              ids.some((id) => !idsOnFirstPage.includes(id)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination has last page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      let page;
+      let pageNum = 0;
+      page = await getJson(engine, { product_id: productId, page: "99" });
+      while (page && pageNum < 5) {
+        pageNum++;
+        page = await page.next?.();
+      }
+      assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+    });
+
+    await t.step("callback", async () => {
+      let pageNum = 0;
+      await new Promise<void>((done) => {
+        getJson(engine, { product_id: productId, page: "99" }, (page) => {
+          pageNum++;
+          if (pageNum < 5 && page.next) {
+            page.next();
+          } else {
+            assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+            done();
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/engines/baidu_test.ts
+++ b/tests/engines/baidu_test.ts
@@ -1,0 +1,201 @@
+// deno-lint-ignore-file no-explicit-any
+import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { spy, Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { _internals } from "../../src/utils.ts";
+import { config, getJson } from "../../mod.ts";
+import {
+  MSG_ASSERT_HAS_LAST_PAGE,
+  MSG_ASSERT_HAS_MULTIPLE_PAGES,
+  MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+} from "./constants.ts";
+
+loadSync({ export: true });
+const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
+const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
+const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
+  ? "http://localhost:3000"
+  : "https://serpapi.com";
+
+describe("baidu", {
+  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+  sanitizeResources: false,
+}, () => {
+  let urlStub: Stub;
+  const engine = "baidu";
+  const q = "coffee";
+
+  beforeAll(() => {
+    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+  });
+
+  beforeEach(() => {
+    config.api_key = SERPAPI_TEST_KEY;
+  });
+
+  afterEach(() => {
+    config.api_key = null;
+  });
+
+  afterAll(() => {
+    urlStub.restore();
+  });
+
+  it("getJson pagination", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      const links: string[] = [];
+      let page;
+      page = await getJson(engine, { q });
+      while (page) {
+        links.push(...page.organic_results.map((r: any) => r.link));
+        if (links.length >= 20) break;
+        page = await page.next?.();
+      }
+      assert(new Set(links).size > 10, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+    });
+
+    await t.step("callback", async () => {
+      const links: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q }, (page) => {
+          links.push(...page.organic_results.map((r: any) => r.link));
+          if (links.length < 20 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(links).size > 10, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination keeps original parameter keys", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const executeSpy = spy(_internals, "execute");
+    config.api_key = null;
+
+    await t.step("async/await", async () => {
+      const page1 = await getJson(engine, {
+        api_key: SERPAPI_TEST_KEY,
+        no_cache: false,
+        q,
+      });
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await page1.next();
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    await t.step("callback", async () => {
+      const page1 = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+        (res) =>
+          getJson(engine, {
+            api_key: SERPAPI_TEST_KEY,
+            no_cache: false,
+            q,
+          }, res),
+      );
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await new Promise((res) => page1.next?.(res));
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    executeSpy.restore();
+  });
+
+  it("getJson pagination with offset + size", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { q });
+    const linksOnFirstPage = firstPage.organic_results.map((r: any) => r.link);
+
+    await t.step("async/await", async () => {
+      const links: string[] = [];
+      let page;
+      page = await getJson(engine, { q, pn: "30", rn: "30" });
+      while (page) {
+        links.push(...page.organic_results.map((r: any) => r.link));
+        if (links.length >= 60) break;
+        page = await page.next?.();
+      }
+      assert(new Set(links).size > 30, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        links.some((link) => !linksOnFirstPage.includes(link)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const links: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q, pn: "30", rn: "30" }, (page) => {
+          links.push(...page.organic_results.map((r: any) => r.link));
+          if (links.length < 60 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(links).size > 30, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              links.some((link) => !linksOnFirstPage.includes(link)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination has last page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      let page;
+      let pageNum = 0;
+      page = await getJson(engine, { q, pn: "750" });
+      while (page && pageNum < 5) {
+        pageNum++;
+        page = await page.next?.();
+      }
+      assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+    });
+
+    await t.step("callback", async () => {
+      let pageNum = 0;
+      await new Promise<void>((done) => {
+        getJson(engine, { q, pn: "750" }, (page) => {
+          pageNum++;
+          if (pageNum < 5 && page.next) {
+            page.next();
+          } else {
+            assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+            done();
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/engines/constants.ts
+++ b/tests/engines/constants.ts
@@ -1,0 +1,4 @@
+export const MSG_ASSERT_HAS_MULTIPLE_PAGES = "Only a single page was fetched";
+export const MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT =
+  "All results were from the first page";
+export const MSG_ASSERT_HAS_LAST_PAGE = "No last page was found";

--- a/tests/engines/duckduckgo_test.ts
+++ b/tests/engines/duckduckgo_test.ts
@@ -1,0 +1,204 @@
+// deno-lint-ignore-file no-explicit-any
+import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { spy, Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { _internals } from "../../src/utils.ts";
+import { config, getJson } from "../../mod.ts";
+import {
+  MSG_ASSERT_HAS_LAST_PAGE,
+  MSG_ASSERT_HAS_MULTIPLE_PAGES,
+  MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+} from "./constants.ts";
+
+loadSync({ export: true });
+const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
+const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
+const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
+  ? "http://localhost:3000"
+  : "https://serpapi.com";
+
+describe("duckduckgo", {
+  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+  sanitizeResources: false,
+}, () => {
+  let urlStub: Stub;
+  const engine = "duckduckgo";
+  const q = "coffee";
+
+  beforeAll(() => {
+    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+  });
+
+  beforeEach(() => {
+    config.api_key = SERPAPI_TEST_KEY;
+  });
+
+  afterEach(() => {
+    config.api_key = null;
+  });
+
+  afterAll(() => {
+    urlStub.restore();
+  });
+
+  it("getJson pagination", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      const links: string[] = [];
+      let page;
+      page = await getJson(engine, { q });
+      while (page) {
+        links.push(...page.organic_results.map((r: any) => r.link));
+        if (links.length >= 50) break;
+        page = await page.next?.();
+      }
+      assert(new Set(links).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+    });
+
+    await t.step("callback", async () => {
+      const links: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q }, (page) => {
+          links.push(...page.organic_results.map((r: any) => r.link));
+          if (links.length < 50 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(links).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination keeps original parameter keys", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const executeSpy = spy(_internals, "execute");
+    config.api_key = null;
+
+    await t.step("async/await", async () => {
+      const page1 = await getJson(engine, {
+        api_key: SERPAPI_TEST_KEY,
+        no_cache: false,
+        q,
+      });
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await page1.next();
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    await t.step("callback", async () => {
+      const page1 = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+        (res) =>
+          getJson(engine, {
+            api_key: SERPAPI_TEST_KEY,
+            no_cache: false,
+            q,
+          }, res),
+      );
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await new Promise((res) => page1.next?.(res));
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    executeSpy.restore();
+  });
+
+  it("getJson pagination with offset", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { q });
+    const linksOnFirstPage: string[] = firstPage.organic_results.map((
+      r: any,
+    ) => r.link);
+
+    await t.step("async/await", async () => {
+      const links: string[] = [];
+      let page;
+      page = await getJson(engine, { q, start: 10 });
+      while (page) {
+        links.push(...page.organic_results.map((r: any) => r.link));
+        if (links.length >= 50) break;
+        page = await page.next?.();
+      }
+
+      assert(new Set(links).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        links.some((id) => !linksOnFirstPage.includes(id)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const links: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q, start: 10 }, (page) => {
+          links.push(...page.organic_results.map((r: any) => r.link));
+          if (links.length < 50 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(links).size > 25, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              links.some((id) => !linksOnFirstPage.includes(id)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination has last page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      let page;
+      let pageNum = 0;
+      page = await getJson(engine, { q, kl: "uk-en", no_cache: true });
+      while (page && pageNum < 8) {
+        pageNum++;
+        page = await page.next?.();
+      }
+      assert(pageNum < 8, MSG_ASSERT_HAS_LAST_PAGE);
+    });
+
+    await t.step("callback", async () => {
+      let pageNum = 0;
+      await new Promise<void>((done) => {
+        getJson(engine, { q, kl: "uk-en" }, (page) => {
+          pageNum++;
+          if (pageNum < 8 && page.next) {
+            page.next();
+          } else {
+            assert(pageNum < 8, MSG_ASSERT_HAS_LAST_PAGE);
+            done();
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/engines/ebay_test.ts
+++ b/tests/engines/ebay_test.ts
@@ -1,0 +1,201 @@
+// deno-lint-ignore-file no-explicit-any
+import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { spy, Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { _internals } from "../../src/utils.ts";
+import { config, getJson } from "../../mod.ts";
+import {
+  MSG_ASSERT_HAS_LAST_PAGE,
+  MSG_ASSERT_HAS_MULTIPLE_PAGES,
+  MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+} from "./constants.ts";
+
+loadSync({ export: true });
+const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
+const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
+const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
+  ? "http://localhost:3000"
+  : "https://serpapi.com";
+
+describe("ebay", {
+  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+  sanitizeResources: false,
+}, () => {
+  let urlStub: Stub;
+  const engine = "ebay";
+  const nkw = "minecraft redstone";
+
+  beforeAll(() => {
+    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+  });
+
+  beforeEach(() => {
+    config.api_key = SERPAPI_TEST_KEY;
+  });
+
+  afterEach(() => {
+    config.api_key = null;
+  });
+
+  afterAll(() => {
+    urlStub.restore();
+  });
+
+  it("getJson pagination", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      const links: string[] = [];
+      let page;
+      page = await getJson(engine, { _nkw: nkw });
+      while (page) {
+        links.push(...page.organic_results.map((r: any) => r.link));
+        if (links.length >= 120) break;
+        page = await page.next?.();
+      }
+      assert(new Set(links).size > 60, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+    });
+
+    await t.step("callback", async () => {
+      const links: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { _nkw: nkw }, (page) => {
+          links.push(...page.organic_results.map((r: any) => r.link));
+          if (links.length < 120 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(links).size > 60, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination keeps original parameter keys", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const executeSpy = spy(_internals, "execute");
+    config.api_key = null;
+
+    await t.step("async/await", async () => {
+      const page1 = await getJson(engine, {
+        api_key: SERPAPI_TEST_KEY,
+        no_cache: false,
+        _nkw: nkw,
+      });
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await page1.next();
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    await t.step("callback", async () => {
+      const page1 = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+        (res) =>
+          getJson(engine, {
+            api_key: SERPAPI_TEST_KEY,
+            no_cache: false,
+            _nkw: nkw,
+          }, res),
+      );
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await new Promise((res) => page1.next?.(res));
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    executeSpy.restore();
+  });
+
+  it("getJson pagination with page + size", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { _nkw: nkw });
+    const linksOnFirstPage = firstPage.organic_results.map((r: any) => r.link);
+
+    await t.step("async/await", async () => {
+      const links: string[] = [];
+      let page;
+      page = await getJson(engine, { _nkw: nkw, _pgn: "2", _ipg: "100" });
+      while (page) {
+        links.push(...page.organic_results.map((r: any) => r.link));
+        if (links.length >= 200) break;
+        page = await page.next?.();
+      }
+      assert(new Set(links).size > 100, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        links.some((link) => !linksOnFirstPage.includes(link)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const links: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { _nkw: nkw, _pgn: "2", _ipg: "100" }, (page) => {
+          links.push(...page.organic_results.map((r: any) => r.link));
+          if (links.length < 200 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(links).size > 100, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              links.some((link) => !linksOnFirstPage.includes(link)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination has last page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      let page;
+      let pageNum = 0;
+      page = await getJson(engine, { _nkw: nkw, _pgn: "7", _ipg: "200" });
+      while (page && pageNum < 5) {
+        pageNum++;
+        page = await page.next?.();
+      }
+      assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+    });
+
+    await t.step("callback", async () => {
+      let pageNum = 0;
+      await new Promise<void>((done) => {
+        getJson(engine, { _nkw: nkw, _pgn: "7", _ipg: "200" }, (page) => {
+          pageNum++;
+          if (pageNum < 5 && page.next) {
+            page.next();
+          } else {
+            assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+            done();
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/engines/google_maps_test.ts
+++ b/tests/engines/google_maps_test.ts
@@ -1,0 +1,210 @@
+// deno-lint-ignore-file no-explicit-any
+import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { spy, Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { _internals } from "../../src/utils.ts";
+import { config, getJson } from "../../mod.ts";
+import {
+  MSG_ASSERT_HAS_LAST_PAGE,
+  MSG_ASSERT_HAS_MULTIPLE_PAGES,
+  MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+} from "./constants.ts";
+
+loadSync({ export: true });
+const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
+const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
+const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
+  ? "http://localhost:3000"
+  : "https://serpapi.com";
+
+describe("google_maps", {
+  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+  sanitizeResources: false,
+}, () => {
+  let urlStub: Stub;
+  const engine = "google_maps";
+  const q = "gas";
+  const type = "search";
+  const ll = "@40.7455096,-74.0083012,16z";
+
+  beforeAll(() => {
+    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+  });
+
+  beforeEach(() => {
+    config.api_key = SERPAPI_TEST_KEY;
+  });
+
+  afterEach(() => {
+    config.api_key = null;
+  });
+
+  afterAll(() => {
+    urlStub.restore();
+  });
+
+  it("getJson pagination", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      const placeIds: string[] = [];
+      let page;
+      page = await getJson(engine, { q, type, ll });
+      while (page) {
+        placeIds.push(...page.local_results.map((r: any) => r.place_id));
+        if (placeIds.length >= 40) break;
+        page = await page.next?.();
+      }
+      assert(new Set(placeIds).size > 20, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+    });
+
+    await t.step("callback", async () => {
+      const placeIds: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q, type, ll }, (page) => {
+          placeIds.push(...page.local_results.map((r: any) => r.place_id));
+          if (placeIds.length < 40 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(placeIds).size > 20, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination keeps original parameter keys", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const executeSpy = spy(_internals, "execute");
+    config.api_key = null;
+
+    await t.step("async/await", async () => {
+      const page1 = await getJson(engine, {
+        api_key: SERPAPI_TEST_KEY,
+        no_cache: false,
+        q,
+        type,
+        ll,
+      });
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await page1.next();
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    await t.step("callback", async () => {
+      const page1 = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+        (res) =>
+          getJson(engine, {
+            api_key: SERPAPI_TEST_KEY,
+            no_cache: false,
+            q,
+            type,
+            ll,
+          }, res),
+      );
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await new Promise((res) => page1.next?.(res));
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    executeSpy.restore();
+  });
+
+  it("getJson pagination with offset", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { q, type, ll });
+    const placeIdsOnFirstPage: string[] = firstPage.local_results.map((
+      r: any,
+    ) => r.place_id);
+
+    await t.step("async/await", async () => {
+      const placeIds: string[] = [];
+      let page;
+      page = await getJson(engine, { q, type, ll, start: 40 });
+      while (page) {
+        placeIds.push(...page.local_results.map((r: any) => r.place_id));
+        if (placeIds.length >= 40) break;
+        page = await page.next?.();
+      }
+
+      assert(new Set(placeIds).size > 20, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        placeIds.some((id) => !placeIdsOnFirstPage.includes(id)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const placeIds: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q, type, ll, start: 20 }, (page) => {
+          placeIds.push(...page.local_results.map((r: any) => r.place_id));
+          if (placeIds.length < 40 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(placeIds).size > 20, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              placeIds.some((id) => !placeIdsOnFirstPage.includes(id)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination has last page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      let page;
+      let pageNum = 0;
+      page = await getJson(engine, { q, type, ll, start: 260 });
+      while (page && pageNum < 5) {
+        pageNum++;
+        page = await page.next?.();
+      }
+      assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+    });
+
+    await t.step("callback", async () => {
+      let pageNum = 0;
+      await new Promise<void>((done) => {
+        getJson(engine, { q, type, ll, start: 260 }, (page) => {
+          pageNum++;
+          if (pageNum < 5 && page.next) {
+            page.next();
+          } else {
+            assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+            done();
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/engines/google_scholar_profiles_test.ts
+++ b/tests/engines/google_scholar_profiles_test.ts
@@ -1,0 +1,203 @@
+// deno-lint-ignore-file no-explicit-any
+import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { spy, Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { _internals } from "../../src/utils.ts";
+import { config, getJson } from "../../mod.ts";
+import {
+  MSG_ASSERT_HAS_LAST_PAGE,
+  MSG_ASSERT_HAS_MULTIPLE_PAGES,
+  MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+} from "./constants.ts";
+
+loadSync({ export: true });
+const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
+const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
+const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
+  ? "http://localhost:3000"
+  : "https://serpapi.com";
+
+describe("google_scholar_profiles", {
+  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+  sanitizeResources: false,
+}, () => {
+  let urlStub: Stub;
+  const engine = "google_scholar_profiles";
+  const mauthors = "mike";
+
+  beforeAll(() => {
+    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+  });
+
+  beforeEach(() => {
+    config.api_key = SERPAPI_TEST_KEY;
+  });
+
+  afterEach(() => {
+    config.api_key = null;
+  });
+
+  afterAll(() => {
+    urlStub.restore();
+  });
+
+  it("getJson pagination", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      const authorIds: string[] = [];
+      let page;
+      page = await getJson(engine, { mauthors });
+      while (page) {
+        authorIds.push(...page.profiles.map((r: any) => r.author_id));
+        if (authorIds.length >= 20) break;
+        page = await page.next?.();
+      }
+      assert(new Set(authorIds).size > 10, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+    });
+
+    await t.step("callback", async () => {
+      const authorIds: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { mauthors }, (page) => {
+          authorIds.push(...page.profiles.map((r: any) => r.author_id));
+          if (authorIds.length < 20 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(authorIds).size > 10, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination keeps original parameter keys", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const executeSpy = spy(_internals, "execute");
+    config.api_key = null;
+
+    await t.step("async/await", async () => {
+      const page1 = await getJson(engine, {
+        api_key: SERPAPI_TEST_KEY,
+        no_cache: false,
+        mauthors,
+      });
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await page1.next();
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    await t.step("callback", async () => {
+      const page1 = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+        (res) =>
+          getJson(engine, {
+            api_key: SERPAPI_TEST_KEY,
+            no_cache: false,
+            mauthors,
+          }, res),
+      );
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await new Promise((res) => page1.next?.(res));
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    executeSpy.restore();
+  });
+
+  it("getJson pagination with token", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { mauthors });
+    const authorIdsOnFirstPage = firstPage.profiles.map((r: any) =>
+      r.author_id
+    );
+
+    await t.step("async/await", async () => {
+      const authorIds: string[] = [];
+      let page;
+      page = await getJson(engine, { mauthors, after_author: "rZlDAYoq__8J" });
+      while (page) {
+        authorIds.push(...page.profiles.map((r: any) => r.author_id));
+        if (authorIds.length >= 20) break;
+        page = await page.next?.();
+      }
+      assert(new Set(authorIds).size > 10, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        authorIds.some((id) => !authorIdsOnFirstPage.includes(id)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const authorIds: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { mauthors, after_author: "rZlDAYoq__8J" }, (page) => {
+          authorIds.push(...page.profiles.map((r: any) => r.author_id));
+          if (authorIds.length < 20 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(authorIds).size > 10, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              authorIds.some((id) => !authorIdsOnFirstPage.includes(id)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination has last page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      let page;
+      let pageNum = 0;
+      page = await getJson(engine, { mauthors, after_author: "UXxiAf3___8J" });
+      while (page && pageNum < 5) {
+        pageNum++;
+        page = await page.next?.();
+      }
+      assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+    });
+
+    await t.step("callback", async () => {
+      let pageNum = 0;
+      await new Promise<void>((done) => {
+        getJson(engine, { mauthors, after_author: "UXxiAf3___8J" }, (page) => {
+          pageNum++;
+          if (pageNum < 5 && page.next) {
+            page.next();
+          } else {
+            assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+            done();
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/engines/home_depot_test.ts
+++ b/tests/engines/home_depot_test.ts
@@ -1,0 +1,285 @@
+// deno-lint-ignore-file no-explicit-any
+import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { spy, Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertMatch,
+} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { _internals } from "../../src/utils.ts";
+import { config, getJson } from "../../mod.ts";
+import {
+  MSG_ASSERT_HAS_LAST_PAGE,
+  MSG_ASSERT_HAS_MULTIPLE_PAGES,
+  MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+} from "./constants.ts";
+
+loadSync({ export: true });
+const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
+const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
+const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
+  ? "http://localhost:3000"
+  : "https://serpapi.com";
+
+describe("home_depot", {
+  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+  sanitizeResources: false,
+}, () => {
+  let urlStub: Stub;
+  const engine = "home_depot";
+  const q = "coffee";
+
+  beforeAll(() => {
+    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+  });
+
+  beforeEach(() => {
+    config.api_key = SERPAPI_TEST_KEY;
+  });
+
+  afterEach(() => {
+    config.api_key = null;
+  });
+
+  afterAll(() => {
+    urlStub.restore();
+  });
+
+  it("getJson pagination", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      const ids: string[] = [];
+      let page;
+      page = await getJson(engine, { q });
+      while (page) {
+        ids.push(...page.products.map((r: any) => r.product_id));
+        if (ids.length >= 48) break;
+        page = await page.next?.();
+      }
+      assert(new Set(ids).size > 24, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+    });
+
+    await t.step("callback", async () => {
+      const ids: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q }, (page) => {
+          ids.push(...page.products.map((r: any) => r.product_id));
+          if (ids.length < 48 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(ids).size > 24, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination keeps original parameter keys", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const executeSpy = spy(_internals, "execute");
+    config.api_key = null;
+
+    await t.step("async/await", async () => {
+      const page1 = await getJson(engine, {
+        api_key: SERPAPI_TEST_KEY,
+        no_cache: false,
+        q,
+      });
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await page1.next();
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    await t.step("callback", async () => {
+      const page1 = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+        (res) =>
+          getJson(engine, {
+            api_key: SERPAPI_TEST_KEY,
+            no_cache: false,
+            q,
+          }, res),
+      );
+      assertMatch(executeSpy.calls[0].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[0].args[1].no_cache, false);
+
+      assertExists(page1.next);
+      await new Promise((res) => page1.next?.(res));
+      assertMatch(executeSpy.calls[1].args[1].api_key as string, /[a-z0-9]+/);
+      assertEquals(executeSpy.calls[1].args[1].no_cache, false);
+    });
+
+    executeSpy.restore();
+  });
+
+  it("getJson pagination with offset + size", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { q, ps: 3 });
+    const idsOnFirstPage = firstPage.products.map((r: any) => r.product_id);
+
+    await t.step("async/await", async () => {
+      const ids: string[] = [];
+      let page;
+      page = await getJson(engine, { q, nao: "6", ps: 3 });
+      while (page) {
+        ids.push(...page.products.map((r: any) => r.product_id));
+        if (ids.length >= 6) break;
+        page = await page.next?.();
+      }
+      assert(new Set(ids).size > 3, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        ids.some((id) => !idsOnFirstPage.includes(id)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const ids: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q, nao: "6", ps: 3 }, (page) => {
+          ids.push(...page.products.map((r: any) => r.product_id));
+          if (ids.length < 6 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(ids).size > 3, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              ids.some((id) => !idsOnFirstPage.includes(id)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination with page + size", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { q, ps: 3 });
+    const idsOnFirstPage = firstPage.products.map((r: any) => r.product_id);
+
+    await t.step("async/await", async () => {
+      const ids: string[] = [];
+      let page;
+      page = await getJson(engine, { q, page: "3", ps: 3 });
+      while (page) {
+        ids.push(...page.products.map((r: any) => r.product_id));
+        if (ids.length >= 6) break;
+        page = await page.next?.();
+      }
+      assert(new Set(ids).size > 3, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        ids.some((id) => !idsOnFirstPage.includes(id)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const ids: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q, page: "3", ps: 3 }, (page) => {
+          ids.push(...page.products.map((r: any) => r.product_id));
+          if (ids.length < 6 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(ids).size > 3, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              ids.some((id) => !idsOnFirstPage.includes(id)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination with offset + page + size", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    const firstPage = await getJson(engine, { q, ps: 3 });
+    const idsOnFirstPage = firstPage.products.map((r: any) => r.product_id);
+
+    await t.step("async/await", async () => {
+      const ids: string[] = [];
+      let page;
+      page = await getJson(engine, { q, nao: "6", page: "3", ps: 3 });
+      while (page) {
+        ids.push(...page.products.map((r: any) => r.product_id));
+        if (ids.length >= 6) break;
+        page = await page.next?.();
+      }
+      assert(new Set(ids).size > 3, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+      assert(
+        ids.some((id) => !idsOnFirstPage.includes(id)),
+        MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+      );
+    });
+
+    await t.step("callback", async () => {
+      const ids: string[] = [];
+      await new Promise<void>((done) => {
+        getJson(engine, { q, nao: "6", page: "3", ps: 3 }, (page) => {
+          ids.push(...page.products.map((r: any) => r.product_id));
+          if (ids.length < 6 && page.next) {
+            page.next();
+          } else {
+            assert(new Set(ids).size > 3, MSG_ASSERT_HAS_MULTIPLE_PAGES);
+            assert(
+              ids.some((id) => !idsOnFirstPage.includes(id)),
+              MSG_ASSERT_HAS_NON_FIRST_PAGE_RESULT,
+            );
+            done();
+          }
+        });
+      });
+    });
+  });
+
+  it("getJson pagination has last page", {
+    ignore: !HAS_API_KEY,
+  }, async (t) => {
+    await t.step("async/await", async () => {
+      let page;
+      let pageNum = 0;
+      page = await getJson(engine, { q, page: "17", ps: 48 });
+      while (page && pageNum < 5) {
+        pageNum++;
+        page = await page.next?.();
+      }
+      assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+    });
+
+    await t.step("callback", async () => {
+      let pageNum = 0;
+      await new Promise<void>((done) => {
+        getJson(engine, { q, page: "17", ps: 48 }, (page) => {
+          pageNum++;
+          if (pageNum < 5 && page.next) {
+            page.next();
+          } else {
+            assert(pageNum < 5, MSG_ASSERT_HAS_LAST_PAGE);
+            done();
+          }
+        });
+      });
+    });
+  });
+});

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -21,6 +21,7 @@ import {
   buildUrl,
   execute,
   extractNextParameters,
+  haveParametersChanged,
 } from "../src/utils.ts";
 
 loadSync({ export: true });
@@ -64,6 +65,106 @@ describe("extractNextParameters", () => {
         hl: "en",
         mauthors: "Mike",
       },
+    );
+  });
+});
+
+describe("haveParametersChanged", () => {
+  it("with different number of properties", () => {
+    assertEquals(
+      haveParametersChanged({ q: "coffee" }, {
+        kl: "us-en",
+        q: "coffee",
+        start: "26",
+      }),
+      true,
+    );
+    assertEquals(
+      haveParametersChanged({ kl: "us-en", q: "coffee", start: "26" }, {
+        q: "coffee",
+      }),
+      true,
+    );
+  });
+
+  it("with same number of properties, but different properties", () => {
+    assertEquals(
+      haveParametersChanged({
+        kl: "us-en",
+        q: "coffee",
+        safe: "1",
+      }, {
+        kl: "us-en",
+        q: "coffee",
+        start: "26",
+      }),
+      true,
+    );
+  });
+
+  it("with same properties, but different values", () => {
+    assertEquals(
+      haveParametersChanged({
+        kl: "us-en",
+        q: "coffee",
+        start: "30",
+      }, {
+        kl: "us-en",
+        q: "coffee",
+        start: "26",
+      }),
+      true,
+    );
+    assertEquals(
+      haveParametersChanged({
+        kl: "us-en",
+        q: "coffee",
+        start: "26",
+      }, {
+        kl: "us-en",
+        q: "coffee",
+        start: "30",
+      }),
+      true,
+    );
+  });
+
+  it("with same properties and same values, regardless of type", () => {
+    assertEquals(
+      haveParametersChanged({
+        kl: "us-en",
+        q: "coffee",
+        start: "30",
+      }, {
+        kl: "us-en",
+        q: "coffee",
+        start: "30",
+      }),
+      false,
+    );
+    assertEquals(
+      haveParametersChanged({
+        kl: "us-en",
+        q: "coffee",
+        start: 30,
+      }, {
+        kl: "us-en",
+        q: "coffee",
+        start: "30",
+      }),
+      false,
+    );
+    assertEquals(
+      haveParametersChanged({
+        kl: "us-en",
+        q: "coffee",
+        start: "30",
+      }, {
+        kl: "us-en",
+        q: "coffee",
+        start: 30,
+      }),
+      false,
     );
   });
 });

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -16,12 +16,57 @@ import {
   assertMatch,
   assertRejects,
 } from "https://deno.land/std@0.170.0/testing/asserts.ts";
-import { _internals, buildUrl, execute } from "../src/utils.ts";
+import {
+  _internals,
+  buildUrl,
+  execute,
+  extractNextParameters,
+} from "../src/utils.ts";
 
 loadSync({ export: true });
 const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
   ? "http://localhost:3000"
   : "https://serpapi.com";
+
+describe("extractNextParameters", () => {
+  it("with serpapi_pagination property", () => {
+    assertEquals(
+      extractNextParameters<"google">({
+        serpapi_pagination: {
+          next:
+            "https://serpapi.com/search.json?device=desktop&engine=google&gl=us&google_domain=google.com&hl=en&location=Austin%2C+Texas%2C+United+States&q=coffee&start=10",
+        },
+      }),
+      {
+        device: "desktop",
+        gl: "us",
+        google_domain: "google.com",
+        hl: "en",
+        location: "Austin, Texas, United States",
+        q: "coffee",
+        start: "10",
+      },
+    );
+  });
+
+  it("with pagination property", () => {
+    assertEquals(
+      extractNextParameters<"google_scholar_profiles">(
+        {
+          pagination: {
+            next:
+              "https://serpapi.com/search.json?after_author=rZlDAYoq__8J&engine=google_scholar_profiles&hl=en&mauthors=Mike",
+          },
+        },
+      ),
+      {
+        after_author: "rZlDAYoq__8J",
+        hl: "en",
+        mauthors: "Mike",
+      },
+    );
+  });
+});
 
 describe("buildUrl", () => {
   let urlStub: Stub;


### PR DESCRIPTION
Handles #2 

This PR implements "Approach 2: Next method" as mentioned in the above issue. Main reasons are that it supports callbacks and it can be used to create an approach similar to Approach 3.

Note that this PR doesn't cover pagination support for `getJsonBySearchId`.

## Tests

I've added tests for 6 of the 7 types of pagination approaches:

- Offset only: `google_maps`
- Page only: `apple_reviews`
- Offset + size: `baidu`
- Page + size: `ebay`
- Offset + page + size: `home_depot`
- Token only: `google_scholar_profiles`
- ~~Offset + page~~: The only engine that uses this approach, `google_product`, relies on an approach that is similar to the `token` only approach.

## Additional notes

- Pagination using the `.next()` method is currently only supported by engines that respond with a `serpapi_pagination.next` property.
  - E.g. `google_jobs` allows for pagination via the `start` offset param, but currently does not return a `serpapi_pagination.next` property. For these cases, you need to send in the `start` offset param manually.
  - There is 1 edge case where [`pagination.next` is used instead](https://github.com/serpapi/serpapi-javascript/blob/2bf164cdfdab3b4403fb798e73f2230ecd8e675e/src/utils.ts#L46). This is for the `google_scholar_profiles` engine.

- Although `yahoo_shopping` returns a `serpapi_pagination.next` property, I've excluded it as there are currently some issues with it
  - https://github.com/serpapi/public-roadmap/issues/562
  - https://github.com/serpapi/public-roadmap/issues/563

- There is a [check if the next parameters are equal to the current parameters](https://github.com/serpapi/serpapi-javascript/blob/0705392ea99f2bafdedbdabc4a817c3f86da25e1/src/serpapi.ts#L99). This check is based on this issue: https://github.com/serpapi/public-roadmap/issues/144.
  - ~~I couldn't replicate it for Ebay, but nonetheless, will keep it in as a safeguard.~~
  - I found that duckduckgo has a similar behaviour and have added tests for it.
  - For duckduckgo, there's a quirk as it has a default parameter. This causes one extra call to be made. Notice the initial params are `{ q: "coffee", start: 30 }` but the next params extracted from `page1` are `{ kl: "us-en", q: "coffee", start: 30}`. This difference means that `page1.next` is returned. It's only after obtaining `page2` that the current params (which includes `kl`) and next params match, implying there's no next page.
  - Sometimes duckduckgo oscillates between different next parameters:
    ```
    { q: "coffee", start: 30 }
    { kl: "us-en", q: "coffee", start: "27" }
    { kl: "us-en", q: "coffee", start: "50" }
    { kl: "us-en", q: "coffee", start: "25" }
    { kl: "us-en", q: "coffee", start: "33" }
    { kl: "us-en", q: "coffee", start: "27" }
    { kl: "us-en", q: "coffee", start: "50" }
    { kl: "us-en", q: "coffee", start: "25" }
    { kl: "us-en", q: "coffee", start: "33" }
    ```