### PR TITLE
Accept search params as the first arg for `getJson`/`getHtml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Get a JSON response based on search parameters.
 - Accepts an optional callback.
 - Get the next page of results by calling the `.next()` method on the returned
   response object.
+- You can pass search parameters as the first argument instead of the engine
+  name. However, you won't get auto-completions for the supported search
+  parameters for that engine.
 
 #### Parameters
 
@@ -150,6 +153,9 @@ const json = await getJson("google", { api_key: API_KEY, q: "coffee" });
 
 // single call (callback)
 getJson("google", { api_key: API_KEY, q: "coffee" }, console.log);
+
+// search params as the first argument (no auto-complete for supported parameters)
+const json = await getJson({ engine: "google", api_key: API_KEY, q: "coffee" });
 ```
 
 ```javascript
@@ -188,6 +194,10 @@ getJson("google", { api_key: API_KEY, q: "coffee" }, (page) => {
   }
 });
 ```
+
+Returns
+**[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)**
+response object
 
 ### getHtml
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ Get a HTML response based on search parameters.
 
 - Accepts an optional callback.
 - Responds with a JSON string if the search request hasn't completed.
+- You can pass search parameters as the first argument instead of the engine
+  name. However, you won't get auto-completions for the supported search
+  parameters for that engine.
 
 #### Parameters
 
@@ -224,7 +227,13 @@ const html = await getHtml("google", { api_key: API_KEY, q: "coffee" });
 
 // callback
 getHtml("google", { api_key: API_KEY, q: "coffee" }, console.log);
+
+// search params as the first argument (no auto-complete for supported parameters)
+const html = await getHtml({ engine: "google", api_key: API_KEY, q: "coffee" });
 ```
+
+Returns
+**[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>**&#x20;
 
 ### getJsonBySearchId
 

--- a/examples/deno/basic_ts/example.ts
+++ b/examples/deno/basic_ts/example.ts
@@ -11,10 +11,14 @@ const params = {
 const response1 = await getJson("google", params);
 console.log(response1["organic_results"]);
 
+// Show result as JSON (async/await with search params as first argument)
+const response2 = await getJson({ engine: "google", ...params });
+console.log(response2["organic_results"]);
+
 // Show result as JSON (callback)
 getJson("google", params, (json) => console.log(json["organic_results"]));
 
 // Use global config
 config.api_key = apiKey;
-const response2 = await getJson("google", { q: "Coffee" });
-console.log(response2["organic_results"]);
+const response3 = await getJson("google", { q: "Coffee" });
+console.log(response3["organic_results"]);

--- a/examples/node/basic_js_commonjs/example.js
+++ b/examples/node/basic_js_commonjs/example.js
@@ -14,13 +14,17 @@ const run = async () => {
   const response1 = await getJson("google", params);
   console.log(response1["organic_results"]);
 
+  // Show result as JSON (async/await with search params as first argument)
+  const response2 = await getJson({ engine: "google", ...params });
+  console.log(response2["organic_results"]);
+
   // Show result as JSON (callback)
   getJson("google", params, (json) => console.log(json["organic_results"]));
 
   // Use global config
   config.api_key = apiKey;
-  const response2 = await getJson("google", { q: "Coffee" });
-  console.log(response2["organic_results"]);
+  const response3 = await getJson("google", { q: "Coffee" });
+  console.log(response3["organic_results"]);
 };
 
 run();

--- a/examples/node/basic_js_esm/example.js
+++ b/examples/node/basic_js_esm/example.js
@@ -13,10 +13,14 @@ const params = {
 const response1 = await getJson("google", params);
 console.log(response1["organic_results"]);
 
+// Show result as JSON (async/await with search params as first argument)
+const response2 = await getJson({ engine: "google", ...params });
+console.log(response2["organic_results"]);
+
 // Show result as JSON (callback)
 getJson("google", params, (json) => console.log(json["organic_results"]));
 
 // Use global config
 config.api_key = apiKey;
-const response2 = await getJson("google", { q: "Coffee" });
-console.log(response2["organic_results"]);
+const response3 = await getJson("google", { q: "Coffee" });
+console.log(response3["organic_results"]);

--- a/examples/node/basic_ts_esm/example.ts
+++ b/examples/node/basic_ts_esm/example.ts
@@ -13,10 +13,14 @@ const params = {
 const response1 = await getJson("google", params);
 console.log(response1["organic_results"]);
 
+// Show result as JSON (async/await with search params as first argument)
+const response2 = await getJson({ engine: "google", ...params });
+console.log(response2["organic_results"]);
+
 // Show result as JSON (callback)
 getJson("google", params, (json) => console.log(json["organic_results"]));
 
 // Use global config
 config.api_key = apiKey;
-const response2 = await getJson("google", { q: "Coffee" });
-console.log(response2["organic_results"]);
+const response3 = await getJson("google", { q: "Coffee" });
+console.log(response3["organic_results"]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export type BaseParameters = {
    */
   timeout?: number;
 };
-export type BaseResponse<P = Record<string | number | symbol, never>> = {
+export type BaseResponse<P = Record<string, unknown>> = {
   search_metadata: {
     id: string;
     status: "Queued" | "Processing" | "Success";

--- a/tests/engines/google_test.ts
+++ b/tests/engines/google_test.ts
@@ -190,10 +190,37 @@ describe("google", {
     assertStringIncludes(response, "</html>");
   });
 
+  it("getHtml for an unmetered query (async/await without engine arg)", async () => {
+    const response = await getHtml({
+      engine,
+      api_key: null,
+      q: "coffee",
+    });
+    assertStringIncludes(response, "<html");
+    assertStringIncludes(response, "<body");
+    assertStringIncludes(response, "</body>");
+    assertStringIncludes(response, "</html>");
+  });
+
   it("getHtml for an unmetered query (callback)", async () => {
     const response = await new Promise<Awaited<ReturnType<typeof getHtml>>>(
       (res) =>
         getHtml(engine, {
+          api_key: null,
+          q: "coffee",
+        }, res),
+    );
+    assertStringIncludes(response, "<html");
+    assertStringIncludes(response, "<body");
+    assertStringIncludes(response, "</body>");
+    assertStringIncludes(response, "</html>");
+  });
+
+  it("getHtml for an unmetered query (callback without engine arg)", async () => {
+    const response = await new Promise<Awaited<ReturnType<typeof getHtml>>>(
+      (res) =>
+        getHtml({
+          engine,
           api_key: null,
           q: "coffee",
         }, res),

--- a/tests/engines/google_test.ts
+++ b/tests/engines/google_test.ts
@@ -72,10 +72,45 @@ describe("google", {
     ]);
   });
 
+  it("getJson for an unmetered query (async/await without engine arg)", async () => {
+    const response = await getJson({
+      engine,
+      api_key: null, // null to support the "coffee" unmetered query
+      q: "coffee",
+    });
+    assertArrayIncludes(Object.keys(response).sort(), [
+      "organic_results",
+      "pagination",
+      "search_information",
+      "search_metadata",
+      "search_parameters",
+      "serpapi_pagination",
+    ]);
+  });
+
   it("getJson for an unmetered query (callback)", async () => {
     const response = await new Promise<Awaited<ReturnType<typeof getJson>>>(
       (res) =>
         getJson(engine, {
+          api_key: null,
+          q: "coffee",
+        }, res),
+    );
+    assertArrayIncludes(Object.keys(response).sort(), [
+      "organic_results",
+      "pagination",
+      "search_information",
+      "search_metadata",
+      "search_parameters",
+      "serpapi_pagination",
+    ]);
+  });
+
+  it("getJson for an unmetered query (callback without engine arg)", async () => {
+    const response = await new Promise<Awaited<ReturnType<typeof getJson>>>(
+      (res) =>
+        getJson({
+          engine,
           api_key: null,
           q: "coffee",
         }, res),


### PR DESCRIPTION
Search parameters can be now be sent in as the first argument of `getJson` and `getHtml` instead of the `engine` argument. Note that you won't get auto-completions for the supported search parameters for that engine.

```ts
// Show result as JSON (async/await with search params as first argument)
const response2 = await getJson({ engine: "google", ...params });
console.log(response2["organic_results"]);
```

- This is useful to align to SerpApi's other libraries.
- Provides a warning-free approach if a particular engine type hasn't been added to the library.

Related to https://github.com/serpapi/serpapi-javascript/issues/5