### PR TITLE
More lenient TypeScript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Added
 
-- Expose `EngineName` and `EngineParameters` types.
+- Expose `EngineName`, `EngineParameters` and `AllowArbitraryParams` types.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ and this project adheres to
 
 ### Added
 
+- Expose `EngineName` and `EngineParameters` types.
+
 ### Changed
 
 - Remove `settings.json`, update CONTRIBUTING.md.
+- Make types more lenient so newly supported engines/parameters whose types have
+  not yet been updated do not throw warnings.
 
 ### Fixed
 

--- a/examples/deno/basic_ts/README.md
+++ b/examples/deno/basic_ts/README.md
@@ -20,6 +20,7 @@ deno run example.ts
   following:
   ```ts
   import {
+    AllowArbitraryParams,
     config,
     getJson,
     GoogleParameters,

--- a/examples/deno/basic_ts/example.ts
+++ b/examples/deno/basic_ts/example.ts
@@ -1,11 +1,16 @@
 import { loadSync } from "https://deno.land/std@0.173.0/dotenv/mod.ts";
-import { config, getJson, GoogleParameters } from "../../../mod.ts";
+import {
+  AllowArbitraryParams,
+  config,
+  getJson,
+  GoogleParameters,
+} from "../../../mod.ts";
 
 const { API_KEY: apiKey } = loadSync();
 const params = {
   q: "Coffee",
   api_key: apiKey,
-} satisfies GoogleParameters;
+} satisfies AllowArbitraryParams<GoogleParameters>;
 
 // Show result as JSON (async/await)
 const response1 = await getJson("google", params);

--- a/examples/deno/pagination_ts/README.md
+++ b/examples/deno/pagination_ts/README.md
@@ -20,6 +20,7 @@ deno run example.ts
   following:
   ```ts
   import {
+    AllowArbitraryParams,
     config,
     getJson,
     GoogleParameters,

--- a/examples/deno/pagination_ts/example.ts
+++ b/examples/deno/pagination_ts/example.ts
@@ -1,5 +1,10 @@
 import { loadSync } from "https://deno.land/std@0.173.0/dotenv/mod.ts";
-import { config, getJson, GoogleParameters } from "../../../mod.ts";
+import {
+  AllowArbitraryParams,
+  config,
+  getJson,
+  GoogleParameters,
+} from "../../../mod.ts";
 
 const { API_KEY: apiKey } = loadSync();
 
@@ -9,7 +14,7 @@ const extractLinks = (results: { link: string }[]) =>
 const params = {
   q: "Coffee",
   api_key: apiKey,
-} satisfies GoogleParameters;
+} satisfies AllowArbitraryParams<GoogleParameters>;
 
 // Pagination (async/await)
 let page1 = await getJson("google", params);

--- a/examples/node/basic_ts_esm/example.ts
+++ b/examples/node/basic_ts_esm/example.ts
@@ -1,5 +1,5 @@
 import * as Dotenv from "dotenv";
-import { config, getJson, GoogleParameters } from "serpapi";
+import { AllowArbitraryParams, config, getJson, GoogleParameters } from "serpapi";
 
 Dotenv.config();
 const apiKey = process.env.API_KEY;
@@ -7,7 +7,7 @@ const apiKey = process.env.API_KEY;
 const params = {
   q: "Coffee",
   api_key: apiKey,
-} satisfies GoogleParameters;
+} satisfies AllowArbitraryParams<GoogleParameters>;
 
 // Show result as JSON (async/await)
 const response1 = await getJson("google", params);

--- a/examples/node/pagination_ts_esm/example.ts
+++ b/examples/node/pagination_ts_esm/example.ts
@@ -1,5 +1,5 @@
 import * as Dotenv from "dotenv";
-import { config, getJson, GoogleParameters } from "serpapi";
+import { AllowArbitraryParams, config, getJson, GoogleParameters } from "serpapi";
 
 Dotenv.config();
 const apiKey = process.env.API_KEY;
@@ -10,7 +10,7 @@ const extractLinks = (results: { link: string }[]) =>
 const params = {
   q: "Coffee",
   api_key: apiKey,
-} satisfies GoogleParameters;
+} satisfies AllowArbitraryParams<GoogleParameters>;
 
 // Pagination (async/await)
 let page1 = await getJson("google", params);

--- a/mod.ts
+++ b/mod.ts
@@ -6,6 +6,7 @@ export { InvalidTimeoutError, MissingApiKeyError } from "./src/errors.ts";
 export type {
   AccountApiParameters,
   AccountInformation,
+  AllowArbitraryParams,
   BaseParameters,
   BaseResponse,
   EngineName,

--- a/mod.ts
+++ b/mod.ts
@@ -8,6 +8,8 @@ export type {
   AccountInformation,
   BaseParameters,
   BaseResponse,
+  EngineName,
+  EngineParameters,
   GetBySearchIdParameters,
   Location,
   Locations,

--- a/src/serpapi.ts
+++ b/src/serpapi.ts
@@ -75,7 +75,7 @@ export async function getJson<
 >(
   engine: E,
   parameters: P,
-  callback?: (json: BaseResponse<P>) => void,
+  callback?: (json: BaseResponse<E>) => void,
 ) {
   const key = validateApiKey(parameters.api_key, true);
   const timeout = validateTimeout(parameters.timeout);
@@ -89,7 +89,7 @@ export async function getJson<
     },
     timeout,
   );
-  const json = await response.json() as BaseResponse<P>;
+  const json = await response.json() as BaseResponse<E>;
   const nextParametersFromResponse = extractNextParameters<E>(json);
   if (
     // https://github.com/serpapi/public-roadmap/issues/562

--- a/src/serpapi.ts
+++ b/src/serpapi.ts
@@ -72,9 +72,7 @@ const SEARCH_ARCHIVE_PATH = `/searches`;
  */
 export async function getJson<
   E extends EngineName = EngineName,
-  P extends AllowArbitraryParams<EngineParameters<E>> = EngineParameters<
-    E
-  >,
+  P extends AllowArbitraryParams<EngineParameters<E>> = EngineParameters<E>,
 >(
   engine: E,
   parameters: P,
@@ -131,7 +129,7 @@ export async function getJson<
  */
 export async function getHtml<
   E extends EngineName = EngineName,
-  P extends EngineParameters<E> = EngineParameters<E>,
+  P extends AllowArbitraryParams<EngineParameters<E>> = EngineParameters<E>,
 >(
   engine: E,
   parameters: P,

--- a/src/serpapi.ts
+++ b/src/serpapi.ts
@@ -2,11 +2,12 @@ import {
   AccountApiParameters,
   AccountInformation,
   BaseResponse,
+  EngineName,
+  EngineParameters,
   GetBySearchIdParameters,
   Locations,
   LocationsApiParameters,
 } from "./types.ts";
-import { EngineMap } from "./engines/engine_map.ts";
 import {
   _internals,
   execute,
@@ -69,11 +70,12 @@ const SEARCH_ARCHIVE_PATH = `/searches`;
  * });
  */
 export async function getJson<
-  E extends keyof EngineMap,
+  E extends EngineName = EngineName,
+  P extends EngineParameters<E> = EngineParameters<E>,
 >(
   engine: E,
-  parameters: EngineMap[E]["parameters"],
-  callback?: (json: BaseResponse<EngineMap[E]["parameters"]>) => void,
+  parameters: P,
+  callback?: (json: BaseResponse<P>) => void,
 ) {
   const key = validateApiKey(parameters.api_key, true);
   const timeout = validateTimeout(parameters.timeout);
@@ -87,9 +89,7 @@ export async function getJson<
     },
     timeout,
   );
-  const json = await response.json() as BaseResponse<
-    EngineMap[E]["parameters"]
-  >;
+  const json = await response.json() as BaseResponse<P>;
   const nextParametersFromResponse = extractNextParameters<E>(json);
   if (
     // https://github.com/serpapi/public-roadmap/issues/562
@@ -126,9 +126,12 @@ export async function getJson<
  * // callback
  * getHtml("google", { api_key: API_KEY, q: "coffee" }, console.log);
  */
-export async function getHtml<E extends keyof EngineMap>(
+export async function getHtml<
+  E extends EngineName = EngineName,
+  P extends EngineParameters<E> = EngineParameters<E>,
+>(
   engine: E,
-  parameters: EngineMap[E]["parameters"],
+  parameters: P,
   callback?: (html: string) => void,
 ) {
   const key = validateApiKey(parameters.api_key, true);

--- a/src/serpapi.ts
+++ b/src/serpapi.ts
@@ -1,6 +1,7 @@
 import {
   AccountApiParameters,
   AccountInformation,
+  AllowArbitraryParams,
   BaseResponse,
   EngineName,
   EngineParameters,
@@ -71,7 +72,7 @@ const SEARCH_ARCHIVE_PATH = `/searches`;
  */
 export async function getJson<
   E extends EngineName = EngineName,
-  P extends (EngineParameters<E> & Record<string, unknown>) = EngineParameters<
+  P extends AllowArbitraryParams<EngineParameters<E>> = EngineParameters<
     E
   >,
 >(

--- a/src/serpapi.ts
+++ b/src/serpapi.ts
@@ -71,7 +71,9 @@ const SEARCH_ARCHIVE_PATH = `/searches`;
  */
 export async function getJson<
   E extends EngineName = EngineName,
-  P extends EngineParameters<E> = EngineParameters<E>,
+  P extends (EngineParameters<E> & Record<string, unknown>) = EngineParameters<
+    E
+  >,
 >(
   engine: E,
   parameters: P,

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export type EngineParameters<
     : BaseParameters & Record<string, unknown>;
 }[E];
 
-export type BaseResponse<P = Record<string, unknown>> = {
+export type BaseResponse<E extends EngineName = EngineName> = {
   search_metadata: {
     id: string;
     status: "Queued" | "Processing" | "Success";
@@ -63,14 +63,15 @@ export type BaseResponse<P = Record<string, unknown>> = {
     raw_html_file: string;
     total_time_taken: number;
   };
-  search_parameters:
-    & { engine: string }
-    & Omit<BaseParameters & P, "api_key" | "no_cache" | "async" | "timeout">;
+  search_parameters: Omit<
+    EngineParameters<E>,
+    "api_key" | "no_cache" | "async" | "timeout"
+  >;
   serpapi_pagination?: { next: string };
   pagination?: { next: string };
   next?: (
-    callback?: (json: BaseResponse<P>) => void,
-  ) => Promise<BaseResponse<P>>;
+    callback?: (json: BaseResponse<E>) => void,
+  ) => Promise<BaseResponse<E>>;
   // deno-lint-ignore no-explicit-any
   [key: string]: any; // TODO(seb): use recursive type
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { EngineMap } from "./engines/engine_map.ts";
+
 export type BaseParameters = {
   /**
    * Parameter defines the device to use to get the results. It can be set to
@@ -39,7 +41,19 @@ export type BaseParameters = {
    */
   timeout?: number;
 };
-export type BaseResponse<P = Record<string | number | symbol, never>> = {
+
+// https://github.com/microsoft/TypeScript/issues/29729
+// deno-lint-ignore ban-types
+type AnyEngineName = string & {};
+export type EngineName = (keyof EngineMap) | AnyEngineName;
+export type EngineParameters<
+  E extends EngineName = EngineName,
+> = {
+  [K in E]: K extends keyof EngineMap ? EngineMap[K]["parameters"]
+    : BaseParameters & Record<string, unknown>;
+}[E];
+
+export type BaseResponse<P = Record<string, unknown>> = {
   search_metadata: {
     id: string;
     status: "Queued" | "Processing" | "Success";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import { EngineMap } from "./engines/engine_map.ts";
 
+/**
+ * Allow arbitrary parameters in addition to parameters in T.
+ */
+export type AllowArbitraryParams<T> = T & Record<string, unknown>;
+
 export type BaseParameters = {
   /**
    * Parameter defines the device to use to get the results. It can be set to

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { EngineMap } from "./engines/engine_map.ts";
+import type { EngineName, EngineParameters } from "./types.ts";
 import { version } from "../version.ts";
 
 type UrlParameters = Record<
@@ -35,16 +35,15 @@ function getBaseUrl() {
   return "https://serpapi.com";
 }
 
-type NextParametersKeys<E extends keyof EngineMap> = Omit<
-  EngineMap[E]["parameters"],
-  "api_key" | "no_cache" | "async" | "timeout"
->;
-type NextParameters<E extends keyof EngineMap> = {
-  [K in keyof NextParametersKeys<E>]: string;
+type NextParameters<E extends EngineName = EngineName> = {
+  [
+    K in keyof Omit<
+      EngineParameters<E>,
+      "api_key" | "no_cache" | "async" | "timeout"
+    >
+  ]: string;
 };
-export function extractNextParameters<
-  E extends keyof EngineMap,
->(json: {
+export function extractNextParameters<E extends EngineName = EngineName>(json: {
   serpapi_pagination?: { next: string };
   pagination?: { next: string };
 }) {


### PR DESCRIPTION
When SerpApi adds support for a new engine or search parameter, the TypeScript types in this library are not immediately updated. For TypeScript devs, they will see warnings that the engine or search parameter does not exist.

This PR looks into making the types more lenient so no warnings appear, while ensuring autocomplete works and providing a way to maintain type safety.

Related to https://github.com/serpapi/serpapi-javascript/issues/5

## Effects

Factor  | Works?
-- | --
Does not show warnings for arbitrary engines | <details><summary>Yes</summary> ![image](https://user-images.githubusercontent.com/577802/218633700-eda5755d-1dca-4cb4-9160-cecb766d15ea.png) </details>
Does not show warnings for arbitrary search params | <details><summary>Yes (because of getJson’s `P extends EngineParameters<E>`)</summary> ![image](https://user-images.githubusercontent.com/577802/218633745-73fa4f1c-6414-4748-8f9a-38a6e360d4b9.png) </details>
Autocomplete for engine | <details><summary>Yes</summary><video src="https://user-images.githubusercontent.com/577802/218636425-f85ade8d-f1e2-4007-aa76-6a061edd2e0b.webm"> </details> 
Autocomplete for search params | <details><summary>Yes</summary><video src="https://user-images.githubusercontent.com/577802/218636445-c9e1f950-5cd5-4adb-bba3-435b35d0c4ce.webm"> </details>
Type-checking for inline params | <details><summary>Yes</summary> ![image](https://user-images.githubusercontent.com/577802/218662493-afb56def-33b6-4272-a9ff-01bc2dcfa99a.png) </details>
Types for safety | <details><summary>Yes via `EngineParamaters<"...">`</summary><video src="https://user-images.githubusercontent.com/577802/218636466-20d932f5-31bd-44d1-9262-d0e7d49b84c0.webm"> </details>
