### PR TITLE
Handle HTTP chunking across multi-byte boundaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -52,6 +52,15 @@ jobs:
     strategy:
       matrix:
         node-version: [7.x, 8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        include:
+          - command: test
+          - command: test:use-openssl-ca
+            node-version: 7.x
+          - command: test:use-openssl-ca
+            node-version: 8.x
+          - command: test:use-openssl-ca
+            node-version: 9.x
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -76,7 +85,7 @@ jobs:
         run: |
           cd smoke_tests/commonjs
           npm i
-          npm test
+          npm run ${{ matrix.command }}
 
   smoke-tests-esm:
     name: "Smoke tests (ESM)"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ more.
 ### Node.js
 
 - Supports Node.js 7.10.1 and newer.
-- Refer to [this example](https://github.com/serpapi/serpapi-javascript/tree/master/examples/node/js_node_7_up) for help.
+- Refer to
+  [this example](https://github.com/serpapi/serpapi-javascript/tree/master/examples/node/js_node_7_up)
+  for help.
 
 ```bash
 npm install serpapi
@@ -40,7 +42,9 @@ getJson({
 
 - If you prefer using the `import` syntax and top-level `await`, you need to use
   at least Node.js 14.8.0.
-- Refer to [this example](https://github.com/serpapi/serpapi-javascript/tree/master/examples/node/js_node_14_up) for help.
+- Refer to
+  [this example](https://github.com/serpapi/serpapi-javascript/tree/master/examples/node/js_node_14_up)
+  for help.
 
 You will need to add `"type": "module"` to your `package.json`:
 
@@ -66,7 +70,9 @@ console.log(response);
 
 - Import directly from deno.land.
 - Usage is otherwise the same as above.
-- Refer to [this example](https://github.com/serpapi/serpapi-javascript/tree/master/examples/deno) for help.
+- Refer to
+  [this example](https://github.com/serpapi/serpapi-javascript/tree/master/examples/deno)
+  for help.
 
 ```ts
 import { getJson } from "https://deno.land/x/serpapi/mod.ts";

--- a/smoke_tests/commonjs/package.json
+++ b/smoke_tests/commonjs/package.json
@@ -4,6 +4,7 @@
     "serpapi": "../../npm"
   },
   "scripts": {
-    "test": "node commonjs.js"
+    "test": "node commonjs.js",
+    "test:use-openssl-ca": "node --use-openssl-ca commonjs.js"
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,6 +63,7 @@ export function execute(
   return new Promise((resolve, reject) => {
     let timer: number;
     const req = https.get(url, (resp) => {
+      resp.setEncoding("utf8");
       let data = "";
 
       // A chunk of data has been recieved.


### PR DESCRIPTION
When a response contains multi-byte UTF-8 characters that cross chunk boundaries, appending the two halves to the intermediate string results in two Unicode Replacement Characters being inserted instead of the two halves being joined.

Use StringDecoder to buffer the partial characters across chunks.

Resolves #22