### PR TITLE
Add support for request options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'  # Build files using a fixed node version
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "22.x" # Build files using a fixed node version
+          registry-url: "https://registry.npmjs.org"
 
       - name: Build npm files
         run: deno task npm
@@ -51,7 +51,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [7.x, 8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [
+          7.x,
+          8.x,
+          9.x,
+          10.x,
+          11.x,
+          12.x,
+          13.x,
+          14.x,
+          15.x,
+          16.x,
+          17.x,
+          18.x,
+          19.x,
+        ]
         include:
           - command: test
           - command: test:use-openssl-ca
@@ -69,7 +83,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Download build files
         uses: actions/download-artifact@v4
@@ -102,7 +116,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Download build files
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x]
+        node-version: [
+          14.x,
+          15.x,
+          16.x,
+          17.x,
+          18.x,
+          19.x,
+          20.x,
+          21.x,
+          22.x,
+          23.x,
+          24.x,
+        ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,11 @@ jobs:
           17.x,
           18.x,
           19.x,
+          20.x,
+          21.x,
+          22.x,
+          23.x,
+          24.x,
         ]
         include:
           - command: test
@@ -107,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x, 23.x, 24.x]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run tests
         env:
           SERPAPI_TEST_KEY: ${{ secrets.SERPAPI_TEST_KEY }}
-        run: deno task test:ci
+        run: deno task test
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,15 +5,15 @@ on: [push]
 jobs:
   build:
     name: "Deno tests and build npm files"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1.1.1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Check formatting
         run: deno fmt --check
@@ -27,9 +27,9 @@ jobs:
         run: deno task test:ci
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'  # Build files using a fixed node version
+          node-version: '22.x'  # Build files using a fixed node version
           registry-url: 'https://registry.npmjs.org'
 
       - name: Build npm files
@@ -39,7 +39,7 @@ jobs:
         run: zip npm.zip ./npm -r
 
       - name: Upload build files for smoke tests
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: npm
           path: npm.zip
@@ -48,7 +48,7 @@ jobs:
   smoke-tests-commonjs:
     name: "Smoke tests (CommonJS)"
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [7.x, 8.x, 9.x, 10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
@@ -63,16 +63,16 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download build files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: npm
 
@@ -90,22 +90,22 @@ jobs:
   smoke-tests-esm:
     name: "Smoke tests (ESM)"
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download build files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: npm
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - 'version.ts'
+      - "version.ts"
 
 jobs:
   release:
@@ -33,8 +33,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "22.x"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Build npm files
         run: deno task npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1.1.1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Check formatting
         run: deno fmt --check
@@ -31,9 +31,9 @@ jobs:
         run: deno task test:ci
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Build npm files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         env:
           SERPAPI_TEST_KEY: ${{ secrets.SERPAPI_TEST_KEY }}
-        run: deno task test:ci
+        run: deno task test
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,7 @@ and you're good to go.
 
 ### Tests that require an API key
 
-- When testing functionality that hits either `localhost` or
-  `https://serpapi.com`, and requires an API key, you need to ensure your API
+- When testing functionality that requires an API key, you need to ensure your API
   key is specified as an environment variable.
 - Create a `.env` file with the following contents, replacing `YOUR_API_KEY`
   with your API key for the appropriate environment.
@@ -91,10 +90,9 @@ it("getJson with api key from config", {
 ## Run tests
 
 ```bash
-deno task test         # Run tests that hit "localhost"
-deno task test:watch   # Run tests that hit "localhost" and in watch mode: https://deno.land/manual/getting_started/command_line_interface#watch-mode
-deno task test:cov     # Get test coverage by running tests that hit "localhost"
-deno task test:ci      # Run tests that hit "https://serpapi.com"
+deno task test         # Run tests
+deno task test:watch   # Run tests and in watch mode: https://deno.land/manual/getting_started/command_line_interface#watch-mode
+deno task test:cov     # Get test coverage by running tests
 ```
 
 ## Run examples on local source files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,8 @@ and you're good to go.
 
 ### Tests that require an API key
 
-- When testing functionality that requires an API key, you need to ensure your API
-  key is specified as an environment variable.
+- When testing functionality that requires an API key, you need to ensure your
+  API key is specified as an environment variable.
 - Create a `.env` file with the following contents, replacing `YOUR_API_KEY`
   with your API key for the appropriate environment.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ more.
 
 ```bash
 npm install serpapi
+# or if you prefer yarn
+yarn add serpapi
 ```
 
 ```js
@@ -124,6 +126,8 @@ First, install the required package:
 
 ```bash
 npm install https-proxy-agent
+# or if you prefer yarn
+yarn add https-proxy-agent
 ```
 
 Then use it in your code:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,39 @@ await getJson({ engine: "google", q: "coffee" }); // uses the API key defined in
 await getJson({ engine: "google", api_key: API_KEY_2, q: "coffee" }); // API_KEY_2 will be used
 ```
 
+### Using a Proxy
+
+You can use a proxy by passing `requestOptions` with an `HttpsProxyAgent`
+instance. This can be done either globally through the config object or
+per-request in the parameters.
+
+First, install the required package:
+
+```bash
+npm install https-proxy-agent
+```
+
+Then use it in your code:
+
+```js
+import { config, getJson } from "serpapi";
+import { HttpsProxyAgent } from "https-proxy-agent";
+
+// Global configuration
+config.requestOptions = {
+  agent: new HttpsProxyAgent("http://proxy-server:port"),
+};
+
+// Or per-request configuration
+await getJson({
+  engine: "google",
+  q: "coffee",
+  requestOptions: {
+    agent: new HttpsProxyAgent("http://proxy-server:port"),
+  },
+});
+```
+
 ## Pagination
 
 Built-in pagination is not supported. Please refer to our pagination examples

--- a/deno.json
+++ b/deno.json
@@ -1,10 +1,9 @@
 {
   "tasks": {
     "docs:gen": "npx documentation readme src/serpapi.ts --section=Functions --shallow && deno fmt",
-    "test": "ENV_TYPE=local deno test tests/ --allow-env --allow-read --allow-net --fail-fast",
+    "test": "deno test tests/ --allow-env --allow-read --allow-net",
     "test:watch": "deno task test --watch",
     "test:cov": "rm -rf cov_profile && deno task test --coverage=cov_profile && deno coverage cov_profile",
-    "test:ci": "deno test tests/ --allow-env --allow-read --allow-net",
     "npm": "deno run -A scripts/build_npm.ts"
   },
   "fmt": {

--- a/deno.json
+++ b/deno.json
@@ -10,21 +10,13 @@
     "exclude": ["npm/", "examples/node", "smoke_tests/"]
   },
   "lint": {
-    "files": {
-      "exclude": ["npm/", "examples/node", "smoke_tests/"]
-    }
+    "exclude": ["npm/", "examples/node", "smoke_tests/"]
   },
   "test": {
-    "files": {
-      "include": ["tests/"]
-    }
+    "include": ["tests/"]
   },
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "deno.ns"
-    ]
+    "lib": ["dom", "dom.iterable", "deno.ns"]
   },
   "lock": false
 }

--- a/deno.json
+++ b/deno.json
@@ -8,9 +8,7 @@
     "npm": "deno run -A scripts/build_npm.ts"
   },
   "fmt": {
-    "files": {
-      "exclude": ["npm/", "examples/node", "smoke_tests/"]
-    }
+    "exclude": ["npm/", "examples/node", "smoke_tests/"]
   },
   "lint": {
     "files": {

--- a/examples/node/js_node_14_up/basic_example.js
+++ b/examples/node/js_node_14_up/basic_example.js
@@ -7,6 +7,7 @@
  */
 
 import * as Dotenv from "dotenv";
+import process from "process";
 import { config, getJson } from "serpapi";
 
 Dotenv.config();

--- a/examples/node/js_node_14_up/pagination_example.js
+++ b/examples/node/js_node_14_up/pagination_example.js
@@ -7,6 +7,7 @@
  */
 
 import * as Dotenv from "dotenv";
+import process from "process";
 import { config, getJson } from "serpapi";
 
 Dotenv.config();

--- a/examples/node/js_node_7_up/basic_example.js
+++ b/examples/node/js_node_7_up/basic_example.js
@@ -3,6 +3,7 @@
  */
 
 const Dotenv = require("dotenv");
+const process = require("process");
 const { config, getJson } = require("serpapi");
 
 Dotenv.config();

--- a/examples/node/js_node_7_up/pagination_example.js
+++ b/examples/node/js_node_7_up/pagination_example.js
@@ -6,6 +6,7 @@ const Dotenv = require("dotenv");
 const { config, getJson } = require("serpapi");
 const url = require("url");
 const qs = require("querystring");
+const process = require("process");
 
 Dotenv.config();
 config.api_key = process.env.API_KEY;

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "https://deno.land/x/dnt@0.37.0/mod.ts";
+import { build, emptyDir } from "https://deno.land/x/dnt@0.40.0/mod.ts";
 import { version } from "../version.ts";
 
 await emptyDir("./npm");

--- a/smoke_tests/commonjs/commonjs.js
+++ b/smoke_tests/commonjs/commonjs.js
@@ -3,6 +3,7 @@
  */
 
 const Dotenv = require("dotenv");
+const process = require("process");
 const {
   config,
   getJson,

--- a/smoke_tests/esm/esm.js
+++ b/smoke_tests/esm/esm.js
@@ -7,6 +7,7 @@
  */
 
 import Dotenv from "dotenv";
+import process from "process";
 import {
   config,
   getAccount,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import process from "node:process";
+
 export type Config = {
   api_key: string | null;
   timeout: number;
@@ -9,9 +11,7 @@ export type Config = {
 function getEnvVar(name: string): string | undefined {
   if (typeof Deno !== "undefined") {
     return Deno.env.get(name);
-    // @ts-ignore: Node.js process
   } else if (typeof process !== "undefined") {
-    // @ts-ignore: Node.js process
     return process.env[name];
   }
   return undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,26 @@
 export type Config = {
   api_key: string | null;
   timeout: number;
+  http_proxy?: string;
+  https_proxy?: string;
+  no_proxy?: string;
 };
+
+function getEnvVar(name: string): string | undefined {
+  if (typeof Deno !== "undefined") {
+    return Deno.env.get(name);
+    // @ts-ignore: Node.js process
+  } else if (typeof process !== "undefined") {
+    // @ts-ignore: Node.js process
+    return process.env[name];
+  }
+  return undefined;
+}
+
 export const config: Config = {
   api_key: null,
   timeout: 60000,
+  http_proxy: getEnvVar("HTTP_PROXY") || getEnvVar("http_proxy"),
+  https_proxy: getEnvVar("HTTPS_PROXY") || getEnvVar("https_proxy"),
+  no_proxy: getEnvVar("NO_PROXY") || getEnvVar("no_proxy"),
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,26 +1,12 @@
-import process from "node:process";
+import http from "node:http";
 
 export type Config = {
   api_key: string | null;
   timeout: number;
-  http_proxy?: string;
-  https_proxy?: string;
-  no_proxy?: string;
+  requestOptions?: http.RequestOptions;
 };
-
-function getEnvVar(name: string): string | undefined {
-  if (typeof Deno !== "undefined") {
-    return Deno.env.get(name);
-  } else if (typeof process !== "undefined") {
-    return process.env[name];
-  }
-  return undefined;
-}
 
 export const config: Config = {
   api_key: null,
   timeout: 60000,
-  http_proxy: getEnvVar("HTTP_PROXY") || getEnvVar("http_proxy"),
-  https_proxy: getEnvVar("HTTPS_PROXY") || getEnvVar("https_proxy"),
-  no_proxy: getEnvVar("NO_PROXY") || getEnvVar("no_proxy"),
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,16 +57,16 @@ export function buildRequestOptions(
       delete clonedParams[k];
     }
   }
-  const base = {
+  const basicOptions = {
     ..._internals.getHostnameAndPort(),
     path: `${path}?${qs.stringify(clonedParams)}`,
     method: "GET",
   };
 
   return {
-    ...base,
     ...config.requestOptions,
     ...(parameters.requestOptions as http.RequestOptions),
+    ...basicOptions,
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,11 @@ export function buildRequestOptions(
 ): http.RequestOptions {
   const clonedParams = { ...parameters };
   for (const k in clonedParams) {
-    if (clonedParams[k] === undefined) {
+    if (
+      k === "requestOptions" ||
+      k === "timeout" ||
+      clonedParams[k] === undefined
+    ) {
       delete clonedParams[k];
     }
   }
@@ -61,8 +65,8 @@ export function buildRequestOptions(
 
   return {
     ...base,
-    ...(parameters.requestOptions as http.RequestOptions),
     ...config.requestOptions,
+    ...(parameters.requestOptions as http.RequestOptions),
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { HttpsProxyAgent } from "npm:https-proxy-agent";
 import { RequestTimeoutError } from "./errors.ts";
 import { config } from "./config.ts";
 import { Buffer } from "node:buffer";
+import process from "node:process";
 
 /**
  * This `_internals` object is needed to support stubbing/spying of
@@ -31,9 +32,7 @@ export function getSource() {
     if (denoVersion) {
       return `deno@${denoVersion},${moduleSource}`;
     }
-    // @ts-ignore: scope of nodejs
   } else if (typeof process == "object") {
-    // @ts-ignore: scope of nodejs
     const nodeVersion = process.versions?.node;
     if (nodeVersion) {
       return `nodejs@${nodeVersion},${moduleSource}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,9 @@ import { version } from "../version.ts";
 import https from "node:https";
 import http from "node:http";
 import qs from "node:querystring";
+import process from "node:process";
 import { RequestTimeoutError } from "./errors.ts";
 import { config } from "./config.ts";
-import process from "node:process";
 
 /**
  * This `_internals` object is needed to support stubbing/spying of

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,6 @@ import http from "node:http";
 import qs from "node:querystring";
 import { RequestTimeoutError } from "./errors.ts";
 import { config } from "./config.ts";
-import { Buffer } from "node:buffer";
 import process from "node:process";
 
 /**
@@ -88,7 +87,7 @@ export function execute(
       let data = "";
 
       // A chunk of data has been received
-      resp.on("data", (chunk: Buffer) => {
+      resp.on("data", (chunk) => {
         data += chunk;
       });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export const _internals = {
   getHostnameAndPort: getHostnameAndPort,
 };
 
-/** Facilitates stubbing in tests, e.g. localhost as the base url */
+/** Facilitates stubbing in tests */
 function getHostnameAndPort() {
   return {
     hostname: "serpapi.com",

--- a/tests/serpapi_test.ts
+++ b/tests/serpapi_test.ts
@@ -40,15 +40,10 @@ import {
 loadSync({ export: true });
 const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
 const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
-const BASE_OPTIONS = Deno.env.get("ENV_TYPE") === "local"
-  ? {
-    hostname: "localhost",
-    port: 3000,
-  }
-  : {
-    hostname: "serpapi.com",
-    port: 443,
-  };
+const BASE_OPTIONS = {
+  hostname: "serpapi.com",
+  port: 443,
+};
 
 describe(
   "getAccount",

--- a/tests/serpapi_test.ts
+++ b/tests/serpapi_test.ts
@@ -40,565 +40,637 @@ import {
 loadSync({ export: true });
 const SERPAPI_TEST_KEY = Deno.env.get("SERPAPI_TEST_KEY") ?? "";
 const HAS_API_KEY = SERPAPI_TEST_KEY.length > 0;
-const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
-  ? "http://localhost:3000"
-  : "https://serpapi.com";
+const BASE_OPTIONS = Deno.env.get("ENV_TYPE") === "local"
+  ? {
+    hostname: "localhost",
+    port: 3000,
+  }
+  : {
+    hostname: "serpapi.com",
+    port: 443,
+  };
 
-describe("getAccount", {
-  sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
-  sanitizeResources: false,
-}, () => {
-  let urlStub: Stub;
+describe(
+  "getAccount",
+  {
+    sanitizeOps: false, // TODO(seb): look into how we can avoid setting these to false
+    sanitizeResources: false,
+  },
+  () => {
+    let urlStub: Stub;
 
-  beforeAll(() => {
-    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
-  });
-
-  afterEach(() => {
-    config.api_key = null;
-  });
-
-  afterAll(() => {
-    urlStub.restore();
-  });
-
-  it("with no api_key", () => {
-    assertRejects(
-      async () => await getAccount({ api_key: "" }),
-      MissingApiKeyError,
-    );
-    assertRejects(
-      async () => await getAccount({}),
-      MissingApiKeyError,
-    );
-    assertRejects(
-      async () => await getAccount(),
-      MissingApiKeyError,
-    );
-  });
-
-  it("with invalid timeout", {
-    ignore: !HAS_API_KEY,
-  }, () => {
-    config.api_key = SERPAPI_TEST_KEY;
-    assertRejects(
-      async () => await getAccount({ timeout: 0 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getAccount({ timeout: -10 }),
-      InvalidTimeoutError,
-    );
-  });
-
-  it("async/await", {
-    ignore: !HAS_API_KEY,
-  }, async () => {
-    const info = await getAccount({
-      api_key: SERPAPI_TEST_KEY,
-      timeout: 10000,
+    beforeAll(() => {
+      urlStub = stub(_internals, "getHostnameAndPort", () => BASE_OPTIONS);
     });
-    assertArrayIncludes(Object.keys(info).sort(), [
-      "account_email",
-      "account_id",
-      "account_rate_limit_per_hour",
-      "api_key",
-      "extra_credits",
-      "last_hour_searches",
-      "plan_id",
-      "plan_monthly_price",
-      "plan_name",
-      "plan_searches_left",
-      "searches_per_month",
-      "this_hour_searches",
-      "this_month_usage",
-      "total_searches_left",
-    ]);
-  });
 
-  it("callback", {
-    ignore: !HAS_API_KEY,
-  }, async () => {
-    const info = await new Promise<Awaited<ReturnType<typeof getAccount>>>(
-      (res) => getAccount({ api_key: SERPAPI_TEST_KEY, timeout: 10000 }, res),
-    );
-    assertArrayIncludes(Object.keys(info).sort(), [
-      "account_email",
-      "account_id",
-      "account_rate_limit_per_hour",
-      "api_key",
-      "extra_credits",
-      "last_hour_searches",
-      "plan_id",
-      "plan_monthly_price",
-      "plan_name",
-      "plan_searches_left",
-      "searches_per_month",
-      "this_hour_searches",
-      "this_month_usage",
-      "total_searches_left",
-    ]);
-  });
-
-  it("rely on global config", {
-    ignore: !HAS_API_KEY,
-  }, async () => {
-    config.api_key = SERPAPI_TEST_KEY;
-    const info = await getAccount();
-    assertArrayIncludes(Object.keys(info).sort(), [
-      "account_email",
-      "account_id",
-      "account_rate_limit_per_hour",
-      "api_key",
-      "extra_credits",
-      "last_hour_searches",
-      "plan_id",
-      "plan_monthly_price",
-      "plan_name",
-      "plan_searches_left",
-      "searches_per_month",
-      "this_hour_searches",
-      "this_month_usage",
-      "total_searches_left",
-    ]);
-  });
-});
-
-describe("getLocations", {
-  sanitizeOps: false,
-  sanitizeResources: false,
-}, () => {
-  let urlStub: Stub;
-
-  beforeAll(() => {
-    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
-  });
-
-  afterAll(() => {
-    urlStub.restore();
-  });
-
-  it("with invalid timeout", () => {
-    assertRejects(
-      async () => await getLocations({ timeout: 0 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getLocations({ timeout: -10 }),
-      InvalidTimeoutError,
-    );
-  });
-
-  it("async/await", async () => {
-    const locations = await getLocations({ limit: 3 });
-    assertInstanceOf(locations, Array);
-    assertEquals(locations.length, 3);
-  });
-
-  it("callback", async () => {
-    const locations = await new Promise<
-      Awaited<ReturnType<typeof getLocations>>
-    >(
-      (res) => getLocations({ limit: 3 }, res),
-    );
-    assertInstanceOf(locations, Array);
-    assertEquals(locations.length, 3);
-  });
-
-  it("without parameters", async () => {
-    const locations = await getLocations();
-    assertInstanceOf(locations, Array);
-  });
-});
-
-describe("getJson", {
-  sanitizeOps: false,
-  sanitizeResources: false,
-}, () => {
-  let urlStub: Stub;
-
-  beforeAll(() => {
-    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
-  });
-
-  afterEach(() => {
-    config.api_key = null;
-  });
-
-  afterAll(() => {
-    urlStub.restore();
-  });
-
-  it("with no api_key", () => {
-    assertRejects(
-      async () => await getJson({ engine: "google", q: "Paris" }),
-      MissingApiKeyError,
-    );
-    assertRejects(
-      async () => await getJson("google", { q: "Paris" }),
-      MissingApiKeyError,
-    );
-    assertRejects(
-      // @ts-ignore testing invalid usage
-      async () => await getJson({}),
-      MissingApiKeyError,
-    );
-  });
-
-  it("with invalid arguments", () => {
-    assertRejects(
-      // @ts-ignore testing invalid usage
-      async () => await getJson("google"),
-      InvalidArgumentError,
-    );
-    assertRejects(
-      // @ts-ignore testing invalid usage
-      async () => await getJson(),
-      InvalidArgumentError,
-    );
-  });
-
-  it("with invalid timeout", () => {
-    config.api_key = "test_api_key";
-    assertRejects(
-      async () => await getJson({ engine: "google", q: "Paris", timeout: 0 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getJson({ engine: "google", q: "Paris", timeout: -10 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getJson("google", { q: "Paris", timeout: 0 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getJson("google", { q: "Paris", timeout: -10 }),
-      InvalidTimeoutError,
-    );
-  });
-
-  it("async/await", {
-    ignore: !HAS_API_KEY,
-  }, async () => {
-    const json = await getJson({
-      engine: "google",
-      q: "Paris",
-      api_key: SERPAPI_TEST_KEY,
-      timeout: 10000,
+    afterEach(() => {
+      config.api_key = null;
     });
-    assertEquals(json.search_metadata["status"], "Success");
-    assertExists(json.organic_results);
 
-    // old API
-    const json2 = await getJson("google", {
-      q: "Paris",
-      api_key: SERPAPI_TEST_KEY,
-      timeout: 10000,
+    afterAll(() => {
+      urlStub.restore();
     });
-    assertEquals(json2.search_metadata.id, json.search_metadata.id);
-  });
 
-  it("callback", {
-    ignore: !HAS_API_KEY,
-  }, async () => {
-    const json = await new Promise<BaseResponse>((done) => {
-      getJson({
+    it("with no api_key", () => {
+      assertRejects(
+        async () => await getAccount({ api_key: "" }),
+        MissingApiKeyError,
+      );
+      assertRejects(async () => await getAccount({}), MissingApiKeyError);
+      assertRejects(async () => await getAccount(), MissingApiKeyError);
+    });
+
+    it(
+      "with invalid timeout",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      () => {
+        config.api_key = SERPAPI_TEST_KEY;
+        assertRejects(
+          async () => await getAccount({ timeout: 0 }),
+          InvalidTimeoutError,
+        );
+        assertRejects(
+          async () => await getAccount({ timeout: -10 }),
+          InvalidTimeoutError,
+        );
+      },
+    );
+
+    it(
+      "async/await",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      async () => {
+        const info = await getAccount({
+          api_key: SERPAPI_TEST_KEY,
+          timeout: 10000,
+        });
+        assertArrayIncludes(Object.keys(info).sort(), [
+          "account_email",
+          "account_id",
+          "account_rate_limit_per_hour",
+          "api_key",
+          "extra_credits",
+          "last_hour_searches",
+          "plan_id",
+          "plan_monthly_price",
+          "plan_name",
+          "plan_searches_left",
+          "searches_per_month",
+          "this_hour_searches",
+          "this_month_usage",
+          "total_searches_left",
+        ]);
+      },
+    );
+
+    it(
+      "callback",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      async () => {
+        const info = await new Promise<Awaited<ReturnType<typeof getAccount>>>(
+          (res) =>
+            getAccount({ api_key: SERPAPI_TEST_KEY, timeout: 10000 }, res),
+        );
+        assertArrayIncludes(Object.keys(info).sort(), [
+          "account_email",
+          "account_id",
+          "account_rate_limit_per_hour",
+          "api_key",
+          "extra_credits",
+          "last_hour_searches",
+          "plan_id",
+          "plan_monthly_price",
+          "plan_name",
+          "plan_searches_left",
+          "searches_per_month",
+          "this_hour_searches",
+          "this_month_usage",
+          "total_searches_left",
+        ]);
+      },
+    );
+
+    it(
+      "rely on global config",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      async () => {
+        config.api_key = SERPAPI_TEST_KEY;
+        const info = await getAccount();
+        assertArrayIncludes(Object.keys(info).sort(), [
+          "account_email",
+          "account_id",
+          "account_rate_limit_per_hour",
+          "api_key",
+          "extra_credits",
+          "last_hour_searches",
+          "plan_id",
+          "plan_monthly_price",
+          "plan_name",
+          "plan_searches_left",
+          "searches_per_month",
+          "this_hour_searches",
+          "this_month_usage",
+          "total_searches_left",
+        ]);
+      },
+    );
+  },
+);
+
+describe(
+  "getLocations",
+  {
+    sanitizeOps: false,
+    sanitizeResources: false,
+  },
+  () => {
+    let urlStub: Stub;
+
+    beforeAll(() => {
+      urlStub = stub(_internals, "getHostnameAndPort", () => BASE_OPTIONS);
+    });
+
+    afterAll(() => {
+      urlStub.restore();
+    });
+
+    it("with invalid timeout", () => {
+      assertRejects(
+        async () => await getLocations({ timeout: 0 }),
+        InvalidTimeoutError,
+      );
+      assertRejects(
+        async () => await getLocations({ timeout: -10 }),
+        InvalidTimeoutError,
+      );
+    });
+
+    it("async/await", async () => {
+      const locations = await getLocations({ limit: 3 });
+      assertInstanceOf(locations, Array);
+      assertEquals(locations.length, 3);
+    });
+
+    it("callback", async () => {
+      const locations = await new Promise<
+        Awaited<ReturnType<typeof getLocations>>
+      >((res) => getLocations({ limit: 3 }, res));
+      assertInstanceOf(locations, Array);
+      assertEquals(locations.length, 3);
+    });
+
+    it("without parameters", async () => {
+      const locations = await getLocations();
+      assertInstanceOf(locations, Array);
+    });
+  },
+);
+
+describe(
+  "getJson",
+  {
+    sanitizeOps: false,
+    sanitizeResources: false,
+  },
+  () => {
+    let urlStub: Stub;
+
+    beforeAll(() => {
+      urlStub = stub(_internals, "getHostnameAndPort", () => BASE_OPTIONS);
+    });
+
+    afterEach(() => {
+      config.api_key = null;
+    });
+
+    afterAll(() => {
+      urlStub.restore();
+    });
+
+    it("with no api_key", () => {
+      assertRejects(
+        async () => await getJson({ engine: "google", q: "Paris" }),
+        MissingApiKeyError,
+      );
+      assertRejects(
+        async () => await getJson("google", { q: "Paris" }),
+        MissingApiKeyError,
+      );
+      assertRejects(
+        // @ts-ignore testing invalid usage
+        async () => await getJson({}),
+        MissingApiKeyError,
+      );
+    });
+
+    it("with invalid arguments", () => {
+      assertRejects(
+        // @ts-ignore testing invalid usage
+        async () => await getJson("google"),
+        InvalidArgumentError,
+      );
+      assertRejects(
+        // @ts-ignore testing invalid usage
+        async () => await getJson(),
+        InvalidArgumentError,
+      );
+    });
+
+    it("with invalid timeout", () => {
+      config.api_key = "test_api_key";
+      assertRejects(
+        async () => await getJson({ engine: "google", q: "Paris", timeout: 0 }),
+        InvalidTimeoutError,
+      );
+      assertRejects(
+        async () =>
+          await getJson({ engine: "google", q: "Paris", timeout: -10 }),
+        InvalidTimeoutError,
+      );
+      assertRejects(
+        async () => await getJson("google", { q: "Paris", timeout: 0 }),
+        InvalidTimeoutError,
+      );
+      assertRejects(
+        async () => await getJson("google", { q: "Paris", timeout: -10 }),
+        InvalidTimeoutError,
+      );
+    });
+
+    it(
+      "async/await",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      async () => {
+        const json = await getJson({
+          engine: "google",
+          q: "Paris",
+          api_key: SERPAPI_TEST_KEY,
+          timeout: 10000,
+        });
+        assertEquals(json.search_metadata["status"], "Success");
+        assertExists(json.organic_results);
+
+        // old API
+        const json2 = await getJson("google", {
+          q: "Paris",
+          api_key: SERPAPI_TEST_KEY,
+          timeout: 10000,
+        });
+        assertEquals(json2.search_metadata.id, json.search_metadata.id);
+      },
+    );
+
+    it(
+      "callback",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      async () => {
+        const json = await new Promise<BaseResponse>((done) => {
+          getJson(
+            {
+              engine: "google",
+              q: "Paris",
+              api_key: SERPAPI_TEST_KEY,
+              timeout: 10000,
+            },
+            done,
+          );
+        });
+        assertEquals(json.search_metadata["status"], "Success");
+        assertExists(json.organic_results);
+
+        // old API
+        const json2 = await new Promise<BaseResponse>((done) => {
+          getJson(
+            "google",
+            {
+              q: "Paris",
+              api_key: SERPAPI_TEST_KEY,
+              timeout: 10000,
+            },
+            done,
+          );
+        });
+        assertEquals(json2.search_metadata.id, json.search_metadata.id);
+      },
+    );
+
+    it("rely on global config", async () => {
+      const executeSpy = spy(_internals, "execute");
+      config.api_key = "test_api_key";
+      try {
+        await getJson({
+          engine: "google",
+          q: "Paris",
+        });
+      } catch {
+        // pass
+      } finally {
+        executeSpy.restore();
+      }
+      assertSpyCalls(executeSpy, 1);
+      assertSpyCallArg(executeSpy, 0, 1, {
+        api_key: "test_api_key",
         engine: "google",
-        q: "Paris",
-        api_key: SERPAPI_TEST_KEY,
-        timeout: 10000,
-      }, done);
-    });
-    assertEquals(json.search_metadata["status"], "Success");
-    assertExists(json.organic_results);
-
-    // old API
-    const json2 = await new Promise<BaseResponse>((done) => {
-      getJson("google", {
-        q: "Paris",
-        api_key: SERPAPI_TEST_KEY,
-        timeout: 10000,
-      }, done);
-    });
-    assertEquals(json2.search_metadata.id, json.search_metadata.id);
-  });
-
-  it("rely on global config", async () => {
-    const executeSpy = spy(_internals, "execute");
-    config.api_key = "test_api_key";
-    try {
-      await getJson({
-        engine: "google",
+        output: "json",
         q: "Paris",
       });
-    } catch {
-      // pass
-    } finally {
-      executeSpy.restore();
-    }
-    assertSpyCalls(executeSpy, 1);
-    assertSpyCallArg(executeSpy, 0, 1, {
-      api_key: "test_api_key",
-      engine: "google",
-      output: "json",
-      q: "Paris",
     });
-  });
 
-  it("api_key param overrides global config", async () => {
-    const executeSpy = spy(_internals, "execute");
-    config.api_key = "test_initial_api_key";
-    try {
-      await getJson({
-        engine: "google",
+    it("api_key param overrides global config", async () => {
+      const executeSpy = spy(_internals, "execute");
+      config.api_key = "test_initial_api_key";
+      try {
+        await getJson({
+          engine: "google",
+          api_key: "test_override_api_key",
+          q: "Paris",
+        });
+      } catch {
+        // pass
+      } finally {
+        executeSpy.restore();
+      }
+      assertSpyCalls(executeSpy, 1);
+      assertSpyCallArg(executeSpy, 0, 1, {
         api_key: "test_override_api_key",
+        engine: "google",
+        output: "json",
         q: "Paris",
       });
-    } catch {
-      // pass
-    } finally {
-      executeSpy.restore();
-    }
-    assertSpyCalls(executeSpy, 1);
-    assertSpyCallArg(executeSpy, 0, 1, {
-      api_key: "test_override_api_key",
-      engine: "google",
-      output: "json",
-      q: "Paris",
     });
-  });
-});
+  },
+);
 
-describe("getHtml", {
-  sanitizeOps: false,
-  sanitizeResources: false,
-}, () => {
-  let urlStub: Stub;
+describe(
+  "getHtml",
+  {
+    sanitizeOps: false,
+    sanitizeResources: false,
+  },
+  () => {
+    let urlStub: Stub;
 
-  beforeAll(() => {
-    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
-  });
-
-  afterEach(() => {
-    config.api_key = null;
-  });
-
-  afterAll(() => {
-    urlStub.restore();
-  });
-
-  it("with no api_key", () => {
-    assertRejects(
-      async () => await getHtml({ engine: "google", q: "Paris" }),
-      MissingApiKeyError,
-    );
-    assertRejects(
-      async () => await getHtml("google", { q: "Paris" }),
-      MissingApiKeyError,
-    );
-    assertRejects(
-      // @ts-ignore testing invalid usage
-      async () => await getHtml({}),
-      MissingApiKeyError,
-    );
-  });
-
-  it("with invalid arguments", () => {
-    assertRejects(
-      // @ts-ignore testing invalid usage
-      async () => await getHtml("google"),
-      InvalidArgumentError,
-    );
-    assertRejects(
-      // @ts-ignore testing invalid usage
-      async () => await getHtml(),
-      InvalidArgumentError,
-    );
-  });
-
-  it("with invalid timeout", {
-    ignore: !HAS_API_KEY,
-  }, () => {
-    config.api_key = SERPAPI_TEST_KEY;
-    assertRejects(
-      async () => await getHtml({ engine: "google", q: "Paris", timeout: 0 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getHtml({ engine: "google", q: "Paris", timeout: -10 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getHtml("google", { q: "Paris", timeout: 0 }),
-      InvalidTimeoutError,
-    );
-    assertRejects(
-      async () => await getHtml("google", { q: "Paris", timeout: -10 }),
-      InvalidTimeoutError,
-    );
-  });
-
-  it("async/await", {
-    ignore: !HAS_API_KEY,
-  }, async () => {
-    const html = await getHtml({
-      engine: "google",
-      q: "Paris",
-      api_key: SERPAPI_TEST_KEY,
-      timeout: 10000,
+    beforeAll(() => {
+      urlStub = stub(_internals, "getHostnameAndPort", () => BASE_OPTIONS);
     });
-    assertEquals(html.includes("Paris"), true);
 
-    // old API
-    const html2 = await getHtml("google", {
-      q: "Paris",
-      api_key: SERPAPI_TEST_KEY,
-      timeout: 10000,
+    afterEach(() => {
+      config.api_key = null;
     });
-    assertEquals(html2, html);
-  });
 
-  it("callback", {
-    ignore: !HAS_API_KEY,
-  }, async () => {
-    const html = await new Promise<string>((done) => {
-      getHtml({
+    afterAll(() => {
+      urlStub.restore();
+    });
+
+    it("with no api_key", () => {
+      assertRejects(
+        async () => await getHtml({ engine: "google", q: "Paris" }),
+        MissingApiKeyError,
+      );
+      assertRejects(
+        async () => await getHtml("google", { q: "Paris" }),
+        MissingApiKeyError,
+      );
+      assertRejects(
+        // @ts-ignore testing invalid usage
+        async () => await getHtml({}),
+        MissingApiKeyError,
+      );
+    });
+
+    it("with invalid arguments", () => {
+      assertRejects(
+        // @ts-ignore testing invalid usage
+        async () => await getHtml("google"),
+        InvalidArgumentError,
+      );
+      assertRejects(
+        // @ts-ignore testing invalid usage
+        async () => await getHtml(),
+        InvalidArgumentError,
+      );
+    });
+
+    it(
+      "with invalid timeout",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      () => {
+        config.api_key = SERPAPI_TEST_KEY;
+        assertRejects(
+          async () =>
+            await getHtml({ engine: "google", q: "Paris", timeout: 0 }),
+          InvalidTimeoutError,
+        );
+        assertRejects(
+          async () =>
+            await getHtml({ engine: "google", q: "Paris", timeout: -10 }),
+          InvalidTimeoutError,
+        );
+        assertRejects(
+          async () => await getHtml("google", { q: "Paris", timeout: 0 }),
+          InvalidTimeoutError,
+        );
+        assertRejects(
+          async () => await getHtml("google", { q: "Paris", timeout: -10 }),
+          InvalidTimeoutError,
+        );
+      },
+    );
+
+    it(
+      "async/await",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      async () => {
+        const html = await getHtml({
+          engine: "google",
+          q: "Paris",
+          api_key: SERPAPI_TEST_KEY,
+          timeout: 10000,
+        });
+        assertEquals(html.includes("Paris"), true);
+
+        // old API
+        const html2 = await getHtml("google", {
+          q: "Paris",
+          api_key: SERPAPI_TEST_KEY,
+          timeout: 10000,
+        });
+        assertEquals(html2, html);
+      },
+    );
+
+    it(
+      "callback",
+      {
+        ignore: !HAS_API_KEY,
+      },
+      async () => {
+        const html = await new Promise<string>((done) => {
+          getHtml(
+            {
+              engine: "google",
+              q: "Paris",
+              api_key: SERPAPI_TEST_KEY,
+              timeout: 10000,
+            },
+            done,
+          );
+        });
+        assertEquals(html.includes("Paris"), true);
+
+        // old API
+        const html2 = await new Promise<string>((done) => {
+          getHtml(
+            "google",
+            {
+              q: "Paris",
+              api_key: SERPAPI_TEST_KEY,
+              timeout: 10000,
+            },
+            done,
+          );
+        });
+        assertEquals(html2, html);
+      },
+    );
+
+    it("rely on global config", async () => {
+      const executeSpy = spy(_internals, "execute");
+      config.api_key = "test_api_key";
+      try {
+        await getHtml({
+          engine: "google",
+          q: "Paris",
+        });
+      } catch {
+        // pass
+      } finally {
+        executeSpy.restore();
+      }
+      assertSpyCalls(executeSpy, 1);
+      assertSpyCallArg(executeSpy, 0, 1, {
+        api_key: "test_api_key",
         engine: "google",
-        q: "Paris",
-        api_key: SERPAPI_TEST_KEY,
-        timeout: 10000,
-      }, done);
-    });
-    assertEquals(html.includes("Paris"), true);
-
-    // old API
-    const html2 = await new Promise<string>((done) => {
-      getHtml("google", {
-        q: "Paris",
-        api_key: SERPAPI_TEST_KEY,
-        timeout: 10000,
-      }, done);
-    });
-    assertEquals(html2, html);
-  });
-
-  it("rely on global config", async () => {
-    const executeSpy = spy(_internals, "execute");
-    config.api_key = "test_api_key";
-    try {
-      await getHtml({
-        engine: "google",
+        output: "html",
         q: "Paris",
       });
-    } catch {
-      // pass
-    } finally {
-      executeSpy.restore();
-    }
-    assertSpyCalls(executeSpy, 1);
-    assertSpyCallArg(executeSpy, 0, 1, {
-      api_key: "test_api_key",
-      engine: "google",
-      output: "html",
-      q: "Paris",
     });
-  });
 
-  it("api_key param overrides global config", async () => {
-    const executeSpy = spy(_internals, "execute");
-    config.api_key = "test_initial_api_key";
-    try {
-      await getHtml({
-        engine: "google",
+    it("api_key param overrides global config", async () => {
+      const executeSpy = spy(_internals, "execute");
+      config.api_key = "test_initial_api_key";
+      try {
+        await getHtml({
+          engine: "google",
+          api_key: "test_override_api_key",
+          q: "Paris",
+        });
+      } catch {
+        // pass
+      } finally {
+        executeSpy.restore();
+      }
+      assertSpyCalls(executeSpy, 1);
+      assertSpyCallArg(executeSpy, 0, 1, {
         api_key: "test_override_api_key",
+        engine: "google",
+        output: "html",
         q: "Paris",
       });
-    } catch {
-      // pass
-    } finally {
-      executeSpy.restore();
-    }
-    assertSpyCalls(executeSpy, 1);
-    assertSpyCallArg(executeSpy, 0, 1, {
-      api_key: "test_override_api_key",
-      engine: "google",
-      output: "html",
-      q: "Paris",
     });
-  });
-});
+  },
+);
 
-describe("getJsonBySearchId", {
-  sanitizeOps: false,
-  sanitizeResources: false,
-  ignore: !HAS_API_KEY,
-}, () => {
-  let id: string;
+describe(
+  "getJsonBySearchId",
+  {
+    sanitizeOps: false,
+    sanitizeResources: false,
+    ignore: !HAS_API_KEY,
+  },
+  () => {
+    let id: string;
 
-  beforeAll(async () => {
-    const response = await getJson({
-      engine: "google",
-      api_key: SERPAPI_TEST_KEY,
-      q: "Paris",
+    beforeAll(async () => {
+      const response = await getJson({
+        engine: "google",
+        api_key: SERPAPI_TEST_KEY,
+        q: "Paris",
+      });
+      let status;
+      ({ id, status } = response["search_metadata"]);
+      assert(id, "Missing search id");
+      assertEquals(status, "Success");
     });
-    let status;
-    ({ id, status } = response["search_metadata"]);
-    assert(id, "Missing search id");
-    assertEquals(status, "Success");
-  });
 
-  it("getJsonBySearchId (async/await)", async () => {
-    const json = await getJsonBySearchId(id, { api_key: SERPAPI_TEST_KEY });
-    assertArrayIncludes(Object.keys(json).sort(), [
-      "organic_results",
-    ]);
-  });
-
-  it("getJsonBySearchId (callback)", async () => {
-    const json = await new Promise<
-      Awaited<ReturnType<typeof getJsonBySearchId>>
-    >((res) => getJsonBySearchId(id, { api_key: SERPAPI_TEST_KEY }, res));
-    assertArrayIncludes(Object.keys(json).sort(), [
-      "organic_results",
-    ]);
-  });
-});
-
-describe("getHtmlBySearchId", {
-  sanitizeOps: false,
-  sanitizeResources: false,
-  ignore: !HAS_API_KEY,
-}, () => {
-  let id: string;
-
-  beforeAll(async () => {
-    const response = await getJson({
-      engine: "google",
-      api_key: SERPAPI_TEST_KEY,
-      q: "Paris",
+    it("getJsonBySearchId (async/await)", async () => {
+      const json = await getJsonBySearchId(id, { api_key: SERPAPI_TEST_KEY });
+      assertArrayIncludes(Object.keys(json).sort(), ["organic_results"]);
     });
-    let status;
-    ({ id, status } = response["search_metadata"]);
-    assert(id, "Missing search id");
-    assertEquals(status, "Success");
-  });
 
-  it("getHtmlBySearchId (async/await)", async () => {
-    const html = await getHtmlBySearchId(id, { api_key: SERPAPI_TEST_KEY });
-    assertStringIncludes(html, "<html");
-    assertStringIncludes(html, "<body");
-    assertStringIncludes(html, "</body>");
-    assertStringIncludes(html, "</html>");
-  });
+    it("getJsonBySearchId (callback)", async () => {
+      const json = await new Promise<
+        Awaited<ReturnType<typeof getJsonBySearchId>>
+      >((res) => getJsonBySearchId(id, { api_key: SERPAPI_TEST_KEY }, res));
+      assertArrayIncludes(Object.keys(json).sort(), ["organic_results"]);
+    });
+  },
+);
 
-  it("getHtmlBySearchId (callback)", async () => {
-    const html = await new Promise<
-      Awaited<ReturnType<typeof getHtmlBySearchId>>
-    >((res) => getHtmlBySearchId(id, { api_key: SERPAPI_TEST_KEY }, res));
-    assertStringIncludes(html, "<html");
-    assertStringIncludes(html, "<body");
-    assertStringIncludes(html, "</body>");
-    assertStringIncludes(html, "</html>");
-  });
-});
+describe(
+  "getHtmlBySearchId",
+  {
+    sanitizeOps: false,
+    sanitizeResources: false,
+    ignore: !HAS_API_KEY,
+  },
+  () => {
+    let id: string;
+
+    beforeAll(async () => {
+      const response = await getJson({
+        engine: "google",
+        api_key: SERPAPI_TEST_KEY,
+        q: "Paris",
+      });
+      let status;
+      ({ id, status } = response["search_metadata"]);
+      assert(id, "Missing search id");
+      assertEquals(status, "Success");
+    });
+
+    it("getHtmlBySearchId (async/await)", async () => {
+      const html = await getHtmlBySearchId(id, { api_key: SERPAPI_TEST_KEY });
+      assertStringIncludes(html, "<html");
+      assertStringIncludes(html, "<body");
+      assertStringIncludes(html, "</body>");
+      assertStringIncludes(html, "</html>");
+    });
+
+    it("getHtmlBySearchId (callback)", async () => {
+      const html = await new Promise<
+        Awaited<ReturnType<typeof getHtmlBySearchId>>
+      >((res) => getHtmlBySearchId(id, { api_key: SERPAPI_TEST_KEY }, res));
+      assertStringIncludes(html, "<html");
+      assertStringIncludes(html, "<body");
+      assertStringIncludes(html, "</body>");
+      assertStringIncludes(html, "</html>");
+    });
+  },
+);

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -177,7 +177,7 @@ describe("buildRequestOptions", () => {
           "User-Agent": "Parameter User Agent",
           "X-Custom-Header": "param-value",
         },
-        hostname: "localhost",
+        agent: true,
       };
 
       config.requestOptions = configOptions;
@@ -191,9 +191,24 @@ describe("buildRequestOptions", () => {
 
       assertEquals(options.headers?.["User-Agent"], "Parameter User Agent");
       assertEquals(options.headers?.["X-Custom-Header"], "param-value");
-      assertEquals(options.hostname, "localhost");
+      assertEquals(options.agent, true);
       assertEquals(options.timeout, 5000);
       assertEquals(options.path, "/search?q=coffee");
+    });
+
+    it("basic options are not allowed to be changed", async () => {
+      config.requestOptions = {
+        hostname: "localhost",
+        port: 3000,
+        path: "/test",
+        method: "POST",
+      };
+
+      const options = await buildRequestOptions("/search", { q: "coffee" });
+      assertEquals(options.hostname, "serpapi.com");
+      assertEquals(options.port, 443);
+      assertEquals(options.path, "/search?q=coffee");
+      assertEquals(options.method, "GET");
     });
   });
 });

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -1,3 +1,5 @@
+import http from "node:http";
+import qs from "node:querystring";
 import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
 import {
   afterAll,
@@ -19,8 +21,6 @@ import {
 } from "../src/utils.ts";
 import { RequestTimeoutError } from "../src/errors.ts";
 import { Config, config } from "../src/config.ts";
-import http from "node:http";
-import qs from "node:querystring";
 
 loadSync({ export: true });
 const BASE_OPTIONS = {

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -23,15 +23,10 @@ import http from "node:http";
 import qs from "node:querystring";
 
 loadSync({ export: true });
-const BASE_OPTIONS = Deno.env.get("ENV_TYPE") === "local"
-  ? {
-    hostname: "localhost",
-    port: 3000,
-  }
-  : {
-    hostname: "serpapi.com",
-    port: 443,
-  };
+const BASE_OPTIONS = {
+  hostname: "serpapi.com",
+  port: 443,
+};
 
 describe("getSource", () => {
   it("use runtime version", async () => {

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -11,13 +11,24 @@ import {
   assertInstanceOf,
   assertMatch,
 } from "https://deno.land/std@0.170.0/testing/asserts.ts";
-import { _internals, buildUrl, execute, getSource } from "../src/utils.ts";
+import {
+  _internals,
+  buildRequestOptions,
+  execute,
+  getSource,
+} from "../src/utils.ts";
 import { RequestTimeoutError } from "../src/errors.ts";
 
 loadSync({ export: true });
-const BASE_URL = Deno.env.get("ENV_TYPE") === "local"
-  ? "http://localhost:3000"
-  : "https://serpapi.com";
+const BASE_OPTIONS = Deno.env.get("ENV_TYPE") === "local"
+  ? {
+    hostname: "localhost",
+    port: 3000,
+  }
+  : {
+    hostname: "serpapi.com",
+    port: 443,
+  };
 
 describe("getSource", () => {
   it("use runtime version", async () => {
@@ -28,11 +39,11 @@ describe("getSource", () => {
   });
 });
 
-describe("buildUrl", () => {
+describe("buildRequestOptions", () => {
   let urlStub: Stub;
 
   beforeAll(() => {
-    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
+    urlStub = stub(_internals, "getHostnameAndPort", () => BASE_OPTIONS);
   });
 
   afterAll(() => {
@@ -40,55 +51,81 @@ describe("buildUrl", () => {
   });
 
   it("with blank path and empty parameters", async () => {
-    assertEquals(await buildUrl("", {}), `${BASE_URL}?`);
+    assertEquals(await buildRequestOptions("", {}), {
+      ...BASE_OPTIONS,
+      method: "GET",
+      path: "?",
+    });
   });
 
   it("with path and empty parameters", async () => {
-    assertEquals(await buildUrl("/", {}), `${BASE_URL}/?`);
+    assertEquals(await buildRequestOptions("/", {}), {
+      ...BASE_OPTIONS,
+      method: "GET",
+      path: "/?",
+    });
   });
 
   it("with path and parameters", async () => {
     assertEquals(
-      await buildUrl("/search", { q: "coffee", gl: "us" }),
-      `${BASE_URL}/search?q=coffee&gl=us`,
+      await buildRequestOptions("/search", { q: "coffee", gl: "us" }),
+      {
+        ...BASE_OPTIONS,
+        method: "GET",
+        path: "/search?q=coffee&gl=us",
+      },
     );
   });
 
   it("with source", async () => {
-    const url = await buildUrl("/search", { source: await getSource() });
+    const options = await buildRequestOptions("/search", {
+      source: await getSource(),
+    });
     assertMatch(
-      url,
+      options.path as string,
       /source=(nodejs|deno)%40\d+\.\d+\.\d+%2Cserpapi%40\d+\.\d+\.\d+$/,
     );
   });
 
   it("with undefined parameters", async () => {
     assertEquals(
-      await buildUrl("/search", { q: "coffee", gl: undefined, hl: null }),
-      `${BASE_URL}/search?q=coffee&hl=`,
+      await buildRequestOptions("/search", {
+        q: "coffee",
+        gl: undefined,
+        hl: null,
+      }),
+      {
+        ...BASE_OPTIONS,
+        method: "GET",
+        path: "/search?q=coffee&hl=",
+      },
     );
   });
 });
 
-describe("execute", {
-  sanitizeOps: false,
-  sanitizeResources: false,
-}, () => {
-  let urlStub: Stub;
+describe(
+  "execute",
+  {
+    sanitizeOps: false,
+    sanitizeResources: false,
+  },
+  () => {
+    let urlStub: Stub;
 
-  beforeAll(() => {
-    urlStub = stub(_internals, "getBaseUrl", () => BASE_URL);
-  });
+    beforeAll(() => {
+      urlStub = stub(_internals, "getHostnameAndPort", () => BASE_OPTIONS);
+    });
 
-  afterAll(() => {
-    urlStub.restore();
-  });
+    afterAll(() => {
+      urlStub.restore();
+    });
 
-  it("with short timeout", async () => {
-    try {
-      await execute("/search", { q: "coffee", gl: "us" }, 1);
-    } catch (e) {
-      assertInstanceOf(e, RequestTimeoutError);
-    }
-  });
-});
+    it("with short timeout", async () => {
+      try {
+        await execute("/search", { q: "coffee", gl: "us" }, 1);
+      } catch (e) {
+        assertInstanceOf(e, RequestTimeoutError);
+      }
+    });
+  },
+);

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -133,8 +133,10 @@ describe("buildRequestOptions", () => {
 
       const options = await buildRequestOptions("/search", params);
 
-      assertEquals(options.headers?.["User-Agent"], "Custom User Agent");
-      assertEquals(options.headers?.["X-Custom-Header"], "param-value");
+      const headers = options.headers as Record<string, string> | undefined;
+
+      assertEquals(headers?.["User-Agent"], "Custom User Agent");
+      assertEquals(headers?.["X-Custom-Header"], "param-value");
       assertEquals(options.timeout, 5000);
       assertEquals(options.path, "/search?q=coffee");
     });
@@ -152,8 +154,10 @@ describe("buildRequestOptions", () => {
 
       const options = await buildRequestOptions("/search", { q: "coffee" });
 
-      assertEquals(options.headers?.["User-Agent"], "Config User Agent");
-      assertEquals(options.headers?.["X-Custom-Header"], "config-value");
+      const headers = options.headers as Record<string, string> | undefined;
+
+      assertEquals(headers?.["User-Agent"], "Config User Agent");
+      assertEquals(headers?.["X-Custom-Header"], "config-value");
       assertEquals(options.timeout, 5000);
       assertEquals(options.path, "/search?q=coffee");
     });
@@ -184,8 +188,10 @@ describe("buildRequestOptions", () => {
 
       const options = await buildRequestOptions("/search", params);
 
-      assertEquals(options.headers?.["User-Agent"], "Parameter User Agent");
-      assertEquals(options.headers?.["X-Custom-Header"], "param-value");
+      const headers = options.headers as Record<string, string> | undefined;
+
+      assertEquals(headers?.["User-Agent"], "Parameter User Agent");
+      assertEquals(headers?.["X-Custom-Header"], "param-value");
       assertEquals(options.agent, true);
       assertEquals(options.timeout, 5000);
       assertEquals(options.path, "/search?q=coffee");


### PR DESCRIPTION
Resolves https://github.com/serpapi/serpapi-javascript/issues/27

This PR was initially for supporting the proxy feature natively. Unfortunately, [HttpsProxyAgent](https://www.npmjs.com/package/https-proxy-agent) isn't supported in some of the older NodeJS versions that this library promises to support.

As a fallback, this PR allows users to pass their own `http.RequestOptions` so they can set the `agent` to be the proxy agent they want.