### PR TITLE
docs: clarify proxy section (fixes #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,13 @@ await getJson({ engine: "google", api_key: API_KEY_2, q: "coffee" }); // API_KEY
 
 ### Using a Proxy
 
-You can use a proxy by passing `requestOptions` with an `HttpsProxyAgent`
-instance. This can be done either globally through the config object or
-per-request in the parameters.
+> **Note:** SerpApi handles proxies on its end — you do **not** need to supply
+> your own proxy to avoid blocks or CAPTCHAs. This option is only for users who
+> need to route all outbound requests through a corporate or network proxy.
+
+You can route requests through your own proxy by passing `requestOptions` with
+an `HttpsProxyAgent` instance. This can be done either globally through the
+config object or per-request in the parameters.
 
 First, install the required package:
 


### PR DESCRIPTION
## Summary

- Added a note to the "Using a Proxy" section clarifying that SerpApi handles proxies server-side
- Users don't need to supply their own proxy to avoid blocks or CAPTCHAs
- This config is only for routing outbound requests through a corporate or network proxy

Addresses the user confusion reported in #32, a user thought they needed to provide their own proxies to use SerpApi.

## Changes

Docs-only change to `README.md`. No code changes.