### PR TITLE
Fix Deno 2 lint and type compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 `serpapi-javascript` is developed using Deno. Refer to
 https://deno.land/manual/getting_started/installation to install Deno.
 
-Ensure you're running at least Deno v1.28.3.
+Ensure you're running at least Deno v1.46.3.
 
 ```bash
 deno --version

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,13 @@
     "test:cov": "rm -rf cov_profile && deno task test --coverage=cov_profile && deno coverage cov_profile",
     "npm": "deno run -A scripts/build_npm.ts"
   },
+  "imports": {
+    "@deno/dnt": "https://deno.land/x/dnt@0.40.0/mod.ts",
+    "@std/dotenv": "https://deno.land/std@0.173.0/dotenv/mod.ts",
+    "@std/testing/asserts": "https://deno.land/std@0.170.0/testing/asserts.ts",
+    "@std/testing/bdd": "https://deno.land/std@0.170.0/testing/bdd.ts",
+    "@std/testing/mock": "https://deno.land/std@0.170.0/testing/mock.ts"
+  },
   "fmt": {
     "exclude": ["npm/", "examples/node", "smoke_tests/"]
   },

--- a/examples/deno/basic_example.ts
+++ b/examples/deno/basic_example.ts
@@ -1,4 +1,4 @@
-import { loadSync } from "https://deno.land/std@0.173.0/dotenv/mod.ts";
+import { loadSync } from "@std/dotenv";
 import { config, getJson } from "../../mod.ts";
 
 const { API_KEY: apiKey } = loadSync();

--- a/examples/deno/pagination_example.ts
+++ b/examples/deno/pagination_example.ts
@@ -1,4 +1,4 @@
-import { loadSync } from "https://deno.land/std@0.173.0/dotenv/mod.ts";
+import { loadSync } from "@std/dotenv";
 import { config, getJson } from "../../mod.ts";
 
 const { API_KEY: apiKey } = loadSync();

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "https://deno.land/x/dnt@0.40.0/mod.ts";
+import { build, emptyDir } from "@deno/dnt";
 import { version } from "../version.ts";
 
 await emptyDir("./npm");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,7 +80,7 @@ export function execute(
   });
 
   return new Promise((resolve, reject) => {
-    let timer: number;
+    let timer: ReturnType<typeof setTimeout>;
 
     const handleResponse = (resp: http.IncomingMessage) => {
       resp.setEncoding("utf8");

--- a/tests/serpapi_test.ts
+++ b/tests/serpapi_test.ts
@@ -1,11 +1,5 @@
-import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  it,
-} from "https://deno.land/std@0.170.0/testing/bdd.ts";
+import { loadSync } from "@std/dotenv";
+import { afterAll, afterEach, beforeAll, describe, it } from "@std/testing/bdd";
 import {
   assert,
   assertArrayIncludes,
@@ -14,14 +8,14 @@ import {
   assertInstanceOf,
   assertRejects,
   assertStringIncludes,
-} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+} from "@std/testing/asserts";
 import {
   assertSpyCallArg,
   assertSpyCalls,
   spy,
   Stub,
   stub,
-} from "https://deno.land/std@0.170.0/testing/mock.ts";
+} from "@std/testing/mock";
 import { _internals } from "../src/utils.ts";
 import {
   BaseResponse,

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -1,18 +1,13 @@
 import http from "node:http";
 import qs from "node:querystring";
-import { loadSync } from "https://deno.land/std@0.170.0/dotenv/mod.ts";
-import {
-  afterAll,
-  beforeAll,
-  describe,
-  it,
-} from "https://deno.land/std@0.170.0/testing/bdd.ts";
-import { Stub, stub } from "https://deno.land/std@0.170.0/testing/mock.ts";
+import { loadSync } from "@std/dotenv";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { Stub, stub } from "@std/testing/mock";
 import {
   assertEquals,
   assertInstanceOf,
   assertMatch,
-} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+} from "@std/testing/asserts";
 import {
   _internals,
   buildRequestOptions,

--- a/tests/validators_test.ts
+++ b/tests/validators_test.ts
@@ -1,12 +1,5 @@
-import {
-  afterEach,
-  describe,
-  it,
-} from "https://deno.land/std@0.170.0/testing/bdd.ts";
-import {
-  assertEquals,
-  assertThrows,
-} from "https://deno.land/std@0.170.0/testing/asserts.ts";
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { assertEquals, assertThrows } from "@std/testing/asserts";
 import { validateApiKey, validateTimeout } from "../src/validators.ts";
 import { config, InvalidTimeoutError, MissingApiKeyError } from "../mod.ts";
 


### PR DESCRIPTION
Newer Deno versions reject inline remote import URLs through the `no-import-prefix` lint rule. This moves those dependencies into the existing `deno.json` import map and uses bare specifiers throughout the project. The repository’s documented Deno 1.28.3 minimum is already incompatible with the existing configuration and `node:` imports. Deno 1.46.3 works.
